### PR TITLE
Use ENV var to define default_comments_limit

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -233,7 +233,7 @@ Rails.application.config.i18n.available_locales = Decidim.available_locales
 Rails.application.config.i18n.default_locale = Decidim.default_locale
 
 ## Set default comments limit. It's used in Decidim::Comments component. Default value is 100.
-Rails.application.config.default_comments_limit = 5
+Rails.application.config.default_comments_limit = ENV.fetch("DECIDIM_COMMENTS_LIMIT") { 100 }.to_i
 
 # Overwrite Devise.allow_unconfirmed_access_for
 Devise.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for


### PR DESCRIPTION
#### :tophat: What? Why?

`Rails.application.config.default_comments_limit`を環境変数 `DECIDIM_COMMENTS_LIMIT` で上書きできるようにします。

#### :pushpin: Related Issues
- Related to https://github.com/codeforjapan/decidim-cfj/pull/223

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 

（どこかに書いておいた方が良さそう？）
