### PR TITLE
rubocop: remove unnecessary disable comment

### DIFF
--- a/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -203,7 +203,7 @@ module Decidim::Verifications
 
     context "when the form is not authorized" do
       before do
-        expect(handler).to receive(:valid?).and_return(false) # rubocop:disable RSpec/StubbedMock
+        expect(handler).to receive(:valid?).and_return(false)
       end
 
       it "is not valid" do


### PR DESCRIPTION
#### :tophat: What? Why?

rubocopのエラーを解消します。

#### :pushpin: Related Issues
- Related to https://github.com/codeforjapan/decidim-cfj/pull/372

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask
