### PR TITLE
Add logging and skip when nil

### DIFF
--- a/db/migrate/20220508115070_drop_decidim_meetings_minutes_table.decidim_meetings.rb
+++ b/db/migrate/20220508115070_drop_decidim_meetings_minutes_table.decidim_meetings.rb
@@ -23,6 +23,13 @@ class DropDecidimMeetingsMinutesTable < ActiveRecord::Migration[6.0]
       minutes = Minutes.find_by(id: action_log.resource_id)
       version = Version.find_by(id: action_log.version_id)
 
+      Rail.logger.info("action_log: #{action_log.inspect}")
+      Rail.logger.info("minutes: #{minutes.inspect}")
+      Rail.logger.info("version_id: #{version&.id}")
+
+      next unless minutes
+      next unless version
+
       version_updates = {
         item_type: "Decidim::Meetings::Meeting",
         item_id: minutes.decidim_meeting_id


### PR DESCRIPTION
#### :tophat: What? Why?

v0252に向けてのmigrationで失敗した場合の原因調査＋回避のため、

* とりあえずもろもろログに吐く
* minutsまたはversionがnilの場合にはスキップする

という処理を追加します。

#### :pushpin: Related Issues

- https://github.com/codeforjapan/decidim-cfj/pull/372

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
