### PR TITLE
Add Decidim::Cw::ApplicationUploader instead of Decidim::ApplicationUploader

### DIFF
--- a/app/uploaders/decidim/cw/application_uploader.rb
+++ b/app/uploaders/decidim/cw/application_uploader.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-module Decidim
+module Decidim::Cw
   # This class deals with uploading files to Decidim. It is intended to just
   # hold the uploads configuration, so you should inherit from this class and
   # then tweak any configuration you need.
   class ApplicationUploader < CarrierWave::Uploader::Base
     include CarrierWave::MiniMagick
+    attr_reader :validable_dimensions
 
-    process :validate_inside_organization
+    delegate :variants, to: :class
 
     # Override the directory where uploaded files will be stored.
     # This is a sensible default for uploaders that are meant to be mounted:
@@ -17,16 +18,6 @@ module Decidim
       return File.join(Decidim.base_uploads_path, default_path) if Decidim.base_uploads_path.present?
 
       default_path
-    end
-
-    # When the uploaded content can't be processed, we want to make sure
-    # not to expose internal tools errors to the users.
-    # We'll show a generic error instead.
-    def manipulate!
-      super
-    rescue CarrierWave::ProcessingError => e
-      Rails.logger.error(e)
-      raise CarrierWave::ProcessingError, I18n.t("carrierwave.errors.general")
     end
 
     # As of Carrierwave 2.0 fog_provider method has been deprecated, and is throwing RuntimeError
@@ -39,6 +30,14 @@ module Decidim
     # We overwrite the downloader to be able to fetch some elements from URL.
     def downloader
       Decidim::Downloader
+    end
+
+    def variant(key)
+      if key && variants[key].present?
+        model.send(mounted_as).variant(variants[key])
+      else
+        model.send(mounted_as)
+      end
     end
 
     # Overwrite: If the content block is in preview mode, then we show the
@@ -62,14 +61,36 @@ module Decidim
 
     protected
 
-    # Validates that the associated model is always within an organization in
-    # order to pass the organization specific settings for the file upload
-    # checks (e.g. file extension, mime type, etc.).
-    def validate_inside_organization
-      return if model.is_a?(Decidim::Organization)
-      return if model.respond_to?(:organization) && model.organization.is_a?(Decidim::Organization)
+    # Checks if the file is an image based on the content type. We need this so
+    # we only create different versions of the file when it's an image.
+    #
+    # new_file - The uploaded file.
+    #
+    # Returns a Boolean.
+    def image?(new_file)
+      content_type = model.try(:content_type) || new_file.content_type
+      content_type.to_s.start_with? "image"
+    end
 
-      raise CarrierWave::IntegrityError, I18n.t("carrierwave.errors.not_inside_organization")
+    class << self
+      # Each class inherits variants from parents and can define their own
+      # variants with the set_variants class method which calss the version
+      # CarrierWave macro to define versions from variants
+      def variants
+        @variants ||= superclass.respond_to?(:variants) ? superclass.variants.dup : {}
+      end
+
+      def set_variants
+        return unless block_given?
+
+        variants.merge!(yield)
+
+        variants.each do |key, value|
+          version key, if: :image? do
+            process value
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Add `url` method that was originally added in Decidim::ApplicationUploader

see also: https://github.com/decidim/decidim/pull/7902

#### :pushpin: Related Issues
- Related to https://github.com/codeforjapan/decidim-cfj/pull/372

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
