### PR TITLE
Fix `Decidim::UserExtension` to support v0.25.2

### DIFF
--- a/decidim-user_extension/app/forms/concerns/decidim/user_extension/forms_definitions.rb
+++ b/decidim-user_extension/app/forms/concerns/decidim/user_extension/forms_definitions.rb
@@ -9,7 +9,7 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
-        include ApplicationHelper
+        include ::Decidim::UserExtension::ApplicationHelper
 
         attribute :user_extension, Decidim::UserExtensionForm
 

--- a/decidim-user_extension/lib/decidim/user_extension/admin_engine.rb
+++ b/decidim-user_extension/lib/decidim/user_extension/admin_engine.rb
@@ -22,12 +22,6 @@ module Decidim
         end
       end
 
-      initializer "decidim_user_extension.admin_engine_additions" do
-        Decidim::Admin::ApplicationController.class_eval do
-          include Decidim::UserExtension::Concerns::Controllers::NeedsUserExtension
-        end
-      end
-
       def load_seed
         nil
       end

--- a/decidim-user_extension/lib/decidim/user_extension/engine.rb
+++ b/decidim-user_extension/lib/decidim/user_extension/engine.rb
@@ -21,7 +21,7 @@ module Decidim
         # root to: "user_extension#index"
       end
 
-      initializer "decidim_user_extension.assets_path" do |app|
+      initializer "decidim_user_extension.assets_path" do
         Decidim.register_assets_path File.expand_path("app/packs", root)
       end
 

--- a/decidim-user_extension/lib/decidim/user_extension/engine.rb
+++ b/decidim-user_extension/lib/decidim/user_extension/engine.rb
@@ -26,44 +26,46 @@ module Decidim
       end
 
       initializer "decidim_user_extension.engine_additions" do
-        Decidim::RegistrationForm.class_eval do
-          include UserExtension::FormsDefinitions
-        end
+        config.to_prepare do
+          Decidim::RegistrationForm.class_eval do
+            include UserExtension::FormsDefinitions
+          end
 
-        Decidim::OmniauthRegistrationForm.class_eval do
-          include UserExtension::FormsDefinitions
-        end
+          Decidim::OmniauthRegistrationForm.class_eval do
+            include UserExtension::FormsDefinitions
+          end
 
-        Decidim::AccountForm.class_eval do
-          include UserExtension::FormsDefinitions
-        end
+          Decidim::AccountForm.class_eval do
+            include UserExtension::FormsDefinitions
+          end
 
-        Decidim::CreateRegistration.class_eval do
-          prepend UserExtension::CreateCommandsOverrides
-        end
+          Decidim::CreateRegistration.class_eval do
+            prepend UserExtension::CreateCommandsOverrides
+          end
 
-        Decidim::UpdateAccount.class_eval do
-          prepend UserExtension::UpdateCommandsOverrides
-        end
+          Decidim::UpdateAccount.class_eval do
+            prepend UserExtension::UpdateCommandsOverrides
+          end
 
-        Decidim::DestroyAccount.class_eval do
-          prepend UserExtension::DestroyCommandsOverrides
-        end
+          Decidim::DestroyAccount.class_eval do
+            prepend UserExtension::DestroyCommandsOverrides
+          end
 
-        Decidim::CreateOmniauthRegistration.class_eval do
-          prepend UserExtension::CreateOmniauthCommandsOverrides
-        end
+          Decidim::CreateOmniauthRegistration.class_eval do
+            prepend UserExtension::CreateOmniauthCommandsOverrides
+          end
 
-        DecidimController.class_eval do
-          include Decidim::UserExtension::Concerns::Controllers::NeedsUserExtension
-        end
+          DecidimController.class_eval do
+            include Decidim::UserExtension::Concerns::Controllers::NeedsUserExtension
+          end
 
-        Decidim::Devise::RegistrationsController.class_eval do
-          prepend Decidim::UserExtension::Concerns::Controllers::AddUserExtensionForm
-        end
+          Decidim::Devise::RegistrationsController.class_eval do
+            prepend Decidim::UserExtension::Concerns::Controllers::AddUserExtensionForm
+          end
 
-        Decidim::Devise::OmniauthRegistrationsController.class_eval do
-          prepend Decidim::UserExtension::Concerns::Controllers::OmniauthAddUserExtensionForm
+          Decidim::Devise::OmniauthRegistrationsController.class_eval do
+            prepend Decidim::UserExtension::Concerns::Controllers::OmniauthAddUserExtensionForm
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

`Decidim::UserExtension` をDecidim v0.25.2で動かすための修正です。

* `Decidim::UserExtension::Engine`で、Decidimで定義済みのクラスに後からいろいろ付け加えているものについて、`config.to_prepare`のブロックで囲むようにして、もろもろ読み込み終えた後 && after_initialize実行前、というタイミングで実行されるようにしました
* `Decidim::UserExtension::AdminEngine`で、`Decidim::Admin::ApplicationController`に`NeedsUserExtension`をincludeさせていたのをやめるようにしました。これは`Decidim::Admin::ApplicationController`のスーパークラスにあたる`DecidimController`ですでに`NeedsUserExtension`をincludeしているため不要でした。
* また、`include ApplicationHelper`がトップレベルのそれではないことを明確化するためフルで書くようにしました
* 合わせてRuboCopで `Lint/UnusedBlockArgument` の警告が出てたのを修正しました（使わないブロック変数を削除）

#### :pushpin: Related Issues
- Fixes https://github.com/codeforjapan/decidim-cfj/issues/408

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
