### PR TITLE
Fix LINE Login; add `omniauth-rails_csrf_protection` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "deface"
 gem "newrelic_rpm"
 
 gem "omniauth-line_login", path: "omniauth-line_login"
+gem "omniauth-rails_csrf_protection"
 
 gem "decidim-user_extension", path: "decidim-user_extension"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -866,6 +866,7 @@ DEPENDENCIES
   listen (~> 3.1)
   newrelic_rpm
   omniauth-line_login!
+  omniauth-rails_csrf_protection
   puma (>= 5.0.0)
   rspec-rails
   rubocop-faker


### PR DESCRIPTION
#### :tophat: What? Why?

v0252でLINE loginをできるようにします。

#### :pushpin: Related Issues
- Related to https://github.com/codeforjapan/decidim-cfj/pull/372

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
