### PR TITLE
Fix FactroyBot in a spec

### DIFF
--- a/spec/forms/decidim/proposals/admin/admin_proposal_form_spec.rb
+++ b/spec/forms/decidim/proposals/admin/admin_proposal_form_spec.rb
@@ -27,7 +27,7 @@ module Decidim
           let(:body) { { ja: "提案のテストその１です。タイトルの文字数をテストします。" } }
           let(:created_in_meeting) { true }
           let(:meeting_component) { create(:meeting_component, participatory_space: participatory_space) }
-          let(:author) { create(:meeting, component: meeting_component) }
+          let(:author) { create(:meeting, :published, component: meeting_component) }
           let!(:meeting_as_author) { author }
 
           let(:params) do

--- a/spec/shared/proposal_form_examples.rb
+++ b/spec/shared/proposal_form_examples.rb
@@ -356,7 +356,7 @@ shared_examples "a proposal form with meeting as author" do |options|
   let(:body) { { en: "Everything would be better" } }
   let(:created_in_meeting) { true }
   let(:meeting_component) { create(:meeting_component, participatory_space: participatory_space) }
-  let(:author) { create(:meeting, component: meeting_component) }
+  let(:author) { create(:meeting, :published, component: meeting_component) }
   let!(:meeting_as_author) { author }
 
   let(:params) do


### PR DESCRIPTION
#### :tophat: What? Why?

https://github.com/codeforjapan/decidim-cfj/pull/467 に対するpull requestです。

Deicdimのv0.26.4をみるとspec内で`create(:meeting)`の引数が変更されていたので、deicidim-cfj側も同様の変更を加えてみます。

#### :pushpin: Related Issues
- Related to https://github.com/codeforjapan/decidim-cfj/pull/467

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
