### PR TITLE
Fix override of `ProposalWizardCreateStepForm`

### DIFF
--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -10,7 +10,7 @@ Rails.application.config.to_prepare do
   #
   # minimum title length should be 8
   Decidim::Proposals::ProposalWizardCreateStepForm.validators.each do |validator|
-    if validator.class == ActiveModel::Validations::LengthValidator && # rubocop:disable Style/Next
+    if validator.class == ProposalLengthValidator && # rubocop:disable Style/Next
        validator.attributes.include?(:title)
 
       fixed_options = validator.options.dup


### PR DESCRIPTION
#### :tophat: What? Why?

validatorのクラスがActiveModel::Validations::LengthValidatorからProposalLengthValidatorに変わっていたのが原因のようだったので、これを置き換えます

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
