### PR TITLE
Update tests to align with v0.28.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,7 @@ RSpec/DescribeClass:
 
 Rails/I18nLocaleAssignment:
   Enabled: false
+
+RSpec/Rails/NegationBeValid:
+  Exclude:
+    - spec/shared/proposal_form_examples.rb

--- a/spec/forms/decidim/proposals/admin/admin_proposal_form_spec.rb
+++ b/spec/forms/decidim/proposals/admin/admin_proposal_form_spec.rb
@@ -13,8 +13,8 @@ module Decidim
 
           after { Rails.application.config.i18n.default_locale = Decidim.default_locale = :ja }
 
-          it_behaves_like "a proposal form", skip_etiquette_validation: true, i18n: true, address_optional_with_geocoding: true
-          it_behaves_like "a proposal form with meeting as author", skip_etiquette_validation: true, i18n: true
+          it_behaves_like "a proposal form", skip_etiquette_validation: true, i18n: true, admin: true
+          it_behaves_like "a proposal form with meeting as author", skip_etiquette_validation: true, i18n: true, admin: true
         end
 
         describe "minimum title length" do

--- a/spec/shared/proposal_form_examples.rb
+++ b/spec/shared/proposal_form_examples.rb
@@ -30,7 +30,6 @@ shared_examples "a proposal form" do |options|
   let(:scope_id) { scope.try(:id) }
   let(:latitude) { 40.1234 }
   let(:longitude) { 2.1234 }
-  let(:has_address) { false }
   let(:address) { nil }
   let(:suggested_hashtags) { [] }
   let(:attachment_params) { nil }
@@ -43,7 +42,6 @@ shared_examples "a proposal form" do |options|
       category_id:,
       scope_id:,
       address:,
-      has_address:,
       meeting_as_author:,
       attachment: attachment_params,
       suggested_hashtags:
@@ -68,10 +66,10 @@ shared_examples "a proposal form" do |options|
     it { is_expected.to be_valid }
   end
 
-  context "when there's no title" do
+  context "when there is no title" do
     let(:title) { nil }
 
-    it { is_expected.not_to be_valid }
+    it { is_expected.to be_invalid }
 
     it "only adds errors to this field" do
       subject.valid?
@@ -92,7 +90,7 @@ shared_examples "a proposal form" do |options|
       end
     end
 
-    it { is_expected.not_to be_valid }
+    it { is_expected.to be_invalid }
   end
 
   context "when the title is the minimum length" do
@@ -117,14 +115,14 @@ shared_examples "a proposal form" do |options|
         end
       end
 
-      it { is_expected.not_to be_valid }
+      it { is_expected.to be_invalid }
     end
   end
 
-  context "when there's no body" do
+  context "when there is no body" do
     let(:body) { nil }
 
-    it { is_expected.not_to be_valid }
+    it { is_expected.to be_invalid }
   end
 
   context "when no category_id" do
@@ -142,43 +140,37 @@ shared_examples "a proposal form" do |options|
   context "with invalid category_id" do
     let(:category_id) { 987 }
 
-    it { is_expected.not_to be_valid }
+    it { is_expected.to be_invalid }
   end
 
   context "when geocoding is enabled" do
     let(:component) { create(:proposal_component, :with_geocoding_enabled, participatory_space:) }
 
-    context "when the has address checkbox is checked" do
-      let(:has_address) { true }
+    context "when the address is not present" do
+      it "does not store the coordinates" do
+        expect(subject).to be_valid
+        expect(subject.address).to be_nil
+        expect(subject.latitude).to be_nil
+        expect(subject.longitude).to be_nil
+      end
+    end
 
-      context "when the address is not present" do
-        it "does not store the coordinates" do
-          expect(subject).to be_valid
-          expect(subject.address).to be_nil
-          expect(subject.latitude).to be_nil
-          expect(subject.longitude).to be_nil
-        end
+    context "when the address is present" do
+      let(:address) { "Some address" }
+
+      before do
+        stub_geocoding(address, [latitude, longitude])
       end
 
-      context "when the address is present" do
-        let(:address) { "Some address" }
-
-        before do
-          stub_geocoding(address, [latitude, longitude])
-        end
-
-        it "validates the address and store its coordinates" do
-          expect(subject).to be_valid
-          expect(subject.latitude).to eq(latitude)
-          expect(subject.longitude).to eq(longitude)
-        end
+      it "validates the address and store its coordinates" do
+        expect(subject).to be_valid
+        expect(subject.latitude).to eq(latitude)
+        expect(subject.longitude).to eq(longitude)
       end
     end
 
     context "when latitude and longitude are manually set" do
       context "when the has address checkbox is unchecked" do
-        let(:has_address) { false }
-
         it "is valid" do
           expect(subject).to be_valid
           expect(subject.latitude).to be_nil
@@ -213,7 +205,6 @@ shared_examples "a proposal form" do |options|
             author: previous_proposal.authors.first,
             category_id: previous_proposal.try(:category_id),
             scope_id: previous_proposal.try(:scope_id),
-            has_address:,
             address:,
             attachment: previous_proposal.try(:attachment_params),
             latitude:,
@@ -273,12 +264,12 @@ shared_examples "a proposal form" do |options|
         category_id:,
         scope_id:,
         address:,
-        has_address:,
         meeting_as_author:,
         suggested_hashtags:,
-        add_photos: [Decidim::Dev.test_file("city.jpeg", "image/jpeg")]
+        attachments_key => [Decidim::Dev.test_file("city.jpeg", "image/jpeg")]
       }
     end
+    let(:attachments_key) { options[:admin] ? :add_photos : :add_documents }
 
     it { is_expected.to be_valid }
 
@@ -289,11 +280,11 @@ shared_examples "a proposal form" do |options|
         expect(subject).not_to be_valid
 
         if options[:i18n]
-          expect(subject.errors.full_messages).to contain_exactly("Title en can't be blank", "Add photos Needs to be reattached")
+          expect(subject.errors.full_messages).to contain_exactly("Title en cannot be blank", "Add photos Needs to be reattached")
           expect(subject.errors.attribute_names).to contain_exactly(:title_en, :add_photos)
         else
-          expect(subject.errors.full_messages).to contain_exactly("Title can't be blank", "Title is too short (under 15 characters)", "Add photos Needs to be reattached")
-          expect(subject.errors.attribute_names).to contain_exactly(:title, :add_photos)
+          expect(subject.errors.full_messages).to contain_exactly("Title cannot be blank", "Title is too short (under 15 characters)", "Add documents Needs to be reattached")
+          expect(subject.errors.attribute_names).to contain_exactly(:title, :add_documents)
         end
       end
     end
@@ -381,10 +372,10 @@ shared_examples "a proposal form with meeting as author" do |options|
     it { is_expected.to be_valid }
   end
 
-  context "when there's no title" do
+  context "when there is no title" do
     let(:title) { nil }
 
-    it { is_expected.not_to be_valid }
+    it { is_expected.to be_invalid }
   end
 
   context "when the title is too long" do
@@ -396,7 +387,7 @@ shared_examples "a proposal form with meeting as author" do |options|
       end
     end
 
-    it { is_expected.not_to be_valid }
+    it { is_expected.to be_invalid }
   end
 
   unless options[:skip_etiquette_validation]
@@ -409,14 +400,14 @@ shared_examples "a proposal form with meeting as author" do |options|
         end
       end
 
-      it { is_expected.not_to be_valid }
+      it { is_expected.to be_invalid }
     end
   end
 
-  context "when there's no body" do
+  context "when there is no body" do
     let(:body) { nil }
 
-    it { is_expected.not_to be_valid }
+    it { is_expected.to be_invalid }
   end
 
   context "when proposals comes from a meeting" do


### PR DESCRIPTION
#### :tophat: What? Why?

v0.28.0に合わせて提案コンポーネントのテストを更新します。

#### :pushpin: Related Issues

- Related to https://github.com/codeforjapan/decidim-cfj/pull/596

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
