### PR TITLE
force to use `:ja` locale

### DIFF
--- a/spec/system/comment_sort_spec.rb
+++ b/spec/system/comment_sort_spec.rb
@@ -18,14 +18,14 @@ describe "Comments", :perform_enqueued do
     comment = create(:comment, commentable:, body: "Most Rated Comment")
     create(:comment_vote, comment:, author: user, weight: 1)
 
-    visit decidim.root_path
+    visit decidim.root_path(locale: :ja)
   end
 
   it "allows user to store selected comment order in cookies", :slow do
     # click_button "同意します"
     visit resource_path
 
-    expect(page).to have_no_content("Comments are disabled at this time")
+    expect(page).to have_no_content("コメントは現時点で無効になっていますが")
 
     expect(page).to have_css(".comment", minimum: 1)
 


### PR DESCRIPTION
#### :tophat: What? Why?

localeが:jaになるようsystem specを修正します。

#### :pushpin: Related Issues
- Related to https://github.com/codeforjapan/decidim-cfj/pull/596

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask
