### PR TITLE
28系でもomniauth-dcp-cityosを導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "deface"
 gem "image_processing"
 gem "newrelic_rpm"
 
+gem "omniauth-cityos-dcp", git: "https://github.com/TheDesignium/omniauth-cityos-dcp.git", tag: "v1.2.0"
 gem "omniauth-line_login", path: "omniauth-line_login"
 gem "omniauth-rails_csrf_protection"
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "deface"
 gem "image_processing"
 gem "newrelic_rpm"
 
-gem "omniauth-cityos-dcp", git: "https://github.com/TheDesignium/omniauth-cityos-dcp.git", tag: "v1.2.0"
+gem "omniauth-cityos-dcp", git: "https://github.com/TheDesignium/omniauth-cityos-dcp.git", tag: "v1.2.2"
 gem "omniauth-line_login", path: "omniauth-line_login"
 gem "omniauth-rails_csrf_protection"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/TheDesignium/omniauth-cityos-dcp.git
+  revision: c9c27abfa052ab52d5b2edc9f299b971fb95a69f
+  tag: v1.2.0
+  specs:
+    omniauth-cityos-dcp (0.1.0)
+      decidim (>= 0.28.0)
+      omniauth-oauth2
+
+GIT
   remote: https://github.com/codeforjapan/decidim-module-decidim_awesome.git
   revision: b2800256f5e147452438686029b3990c89fb21be
   branch: develop
@@ -917,6 +926,7 @@ DEPENDENCIES
   letter_opener_web
   listen (~> 3.1)
   newrelic_rpm
+  omniauth-cityos-dcp!
   omniauth-line_login!
   omniauth-rails_csrf_protection
   puma (>= 6.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/TheDesignium/omniauth-cityos-dcp.git
-  revision: c9c27abfa052ab52d5b2edc9f299b971fb95a69f
-  tag: v1.2.0
+  revision: ae135dc3f01f06a13ec4d24c8327e19b10cf701f
+  tag: v1.2.2
   specs:
     omniauth-cityos-dcp (0.1.0)
       decidim (>= 0.28.0)

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -512,6 +512,3 @@ Devise.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for
 Rails.application.config.to_prepare do
   Decidim::Api::Schema.max_complexity = 100_000
 end
-
-Decidim.icons.register(name: "line-fill", icon: "line-fill", category: "system", description: "", engine: :core)
-Decidim.icons.register(name: "facebook", icon: "facebook", category: "system", description: "", engine: :core)

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -514,3 +514,4 @@ Rails.application.config.to_prepare do
 end
 
 Decidim.icons.register(name: "line-fill", icon: "line-fill", category: "system", description: "", engine: :core)
+Decidim.icons.register(name: "facebook", icon: "facebook", category: "system", description: "", engine: :core)


### PR DESCRIPTION
#### :tophat: What? Why?

`v1.1.0`では、28系に対応していないため、
`v1.2.0`で対応させた

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
