### PR TITLE
Add new content block: Last Comment

### DIFF
--- a/.github/workflows/_check.yaml
+++ b/.github/workflows/_check.yaml
@@ -72,8 +72,8 @@ jobs:
       - name: check imagemagick
         run: |
           export PATH=${GITHUB_WORKSPACE}/vendor/imagemagick7/bin:${PATH}
-          which convert
-          convert -version
+          which mogrify
+          mogrify -version
 
       - name: Set up Ruby 3.1.1
         uses: ruby/setup-ruby@v1
@@ -120,4 +120,5 @@ jobs:
 
       - name: Test with RSpec
         run: |
+          export PATH=${GITHUB_WORKSPACE}/vendor/imagemagick7/bin:${PATH}
           bundle exec rails spec

--- a/app/cells/decidim/content_blocks/last_comment/show.erb
+++ b/app/cells/decidim/content_blocks/last_comment/show.erb
@@ -1,0 +1,14 @@
+<section id="last_comment" class="home__section">
+  <div class="home__section-header">
+    <h2 class="home__section-title">
+      <%= t("decidim.content_blocks.last_comment.title") %>
+    </h2>
+    <%= link_to last_activities_path, class: "button button__sm button__text-secondary" do %>
+        <%= t("view_all", scope: "decidim.content_blocks.last_comment") %>
+        <%= icon "arrow-right-line", class: "fill-current" %>
+      <% end %>
+  </div>
+  <% valid_comments.each_slice(4) do |column_activities| %>
+    <%= cell "decidim/activities", column_activities %>
+  <% end %>
+</section>

--- a/app/cells/decidim/content_blocks/last_comment_cell.rb
+++ b/app/cells/decidim/content_blocks/last_comment_cell.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentBlocks
+    # A cell to be rendered as a content block with the latest comments performed
+    # in a Decidim Organization.
+    class LastCommentCell < Decidim::ViewModel
+      include Decidim::Core::Engine.routes.url_helpers
+
+      def show
+        return if valid_comments.empty?
+
+        render
+      end
+
+      # The comments to be displayed at the content block.
+      #
+      # We need to build the collection this way because an ActionLog has
+      # polymorphic relations to different kind of models, and these models
+      # might not be available (a proposal might have been hidden or withdrawn).
+      #
+      # Since these conditions can't always be filtered with a database search
+      # we ask for more comments than we actually need and then loop until there
+      # are enough of them.
+      #
+      # Returns an Array of ActionLogs.
+      def valid_comments
+        return @valid_comments if defined?(@valid_comments)
+
+        valid_comments_count = 0
+        @valid_comments = []
+
+        comments.includes([:user]).each do |comment|
+          break if valid_comments_count == comments_to_show
+
+          if comment.visible_for?(current_user)
+            @valid_comments << comment
+            valid_comments_count += 1
+          end
+        end
+
+        @valid_comments
+      end
+
+      private
+
+      # A MD5 hash of model attributes because is needed because
+      # it ensures the cache version value will always be the same size
+      def cache_hash
+        hash = []
+        hash << "decidim/content_blocks/last_comment"
+        hash << Digest::MD5.hexdigest(valid_comments.map(&:cache_key_with_version).to_s)
+        hash << I18n.locale.to_s
+
+        hash.join(Decidim.cache_key_separator)
+      end
+
+      def comments
+        @comments ||= Decidim::LastActivity.new(current_organization, current_user: current_user).query.where(resource_type: 'Decidim::Comments::Comment').limit(comments_to_show * 6)
+      end
+
+      def comments_to_show
+        options[:comments_count] || 16
+      end
+    end
+  end
+end

--- a/app/cells/decidim/content_blocks/last_comment_cell.rb
+++ b/app/cells/decidim/content_blocks/last_comment_cell.rb
@@ -56,7 +56,10 @@ module Decidim
       end
 
       def comments
-        @comments ||= Decidim::LastActivity.new(current_organization, current_user: current_user).query.where(resource_type: 'Decidim::Comments::Comment').limit(comments_to_show * 6)
+        @comments ||= Decidim::LastActivity.new(
+          current_organization,
+          current_user:
+        ).query.where(resource_type: "Decidim::Comments::Comment").limit(comments_to_show * 6)
       end
 
       def comments_to_show

--- a/config/initializers/content_block.rb
+++ b/config/initializers/content_block.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Decidim.content_blocks.register(:homepage, :last_comment) do |content_block|
+  content_block.cell = "decidim/content_blocks/last_comment"
+  content_block.public_name_key = "decidim.content_blocks.last_comment.name"
+  content_block.default!
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,11 @@ en:
         title: Title
         body: Body
   decidim:
+    content_blocks:
+      last_comment:
+        name: 最近のコメント
+        title: 最近のコメント
+        view_all: すべて表示
     debates:
       debates:
         versions:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -78,6 +78,10 @@ ja:
       last_activity:
         name: 最近のアクティビティ
         title: 最近のアクティビティ
+      last_comment:
+        name: 最近のコメント
+        title: 最近のコメント
+        view_all: すべて表示
     debates:
       debates:
         filters:


### PR DESCRIPTION
#### :tophat: What? Why?

トップページに「最新のコメント」を表示するためのcontent blockを追加します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

管理画面での表示

<img  alt="last_comment" src="https://github.com/user-attachments/assets/bb0983a4-1e3a-4e79-9f1b-08fdb212d2f7" />

トップページでの表示

<img width="1000" alt="last_comment_list" src="https://github.com/user-attachments/assets/508c85f5-8fc2-4d74-95a1-8bb96d62f07c" />
