### PR TITLE
make emitUpdate true in `setContent` to enable immediate changes

### DIFF
--- a/app/packs/src/decidim/cfj/editor/extensions/tag_edit/index.js
+++ b/app/packs/src/decidim/cfj/editor/extensions/tag_edit/index.js
@@ -19,7 +19,7 @@ export default Node.create({
             rows: 10,
             cols: 80,
            });
-          let tagsrc = this.editor.getHTML();
+          const tagsrc = this.editor.getHTML();
 
           const dialogState = await tagEditDialog.toggle({ tagsrc });
           if (dialogState !== "save") {
@@ -27,8 +27,7 @@ export default Node.create({
           }
 
           const newTagsrc = tagEditDialog.getValue("tagsrc");
-          this.editor.commands.setContent(newTagsrc);
-
+          this.editor.commands.setContent(newTagsrc, true);
           this.editor.commands.focus(null, { scrollIntoView: false });
           return false;
         }


### PR DESCRIPTION
#### :tophat: What? Why?

HTMLタグエディタでコンテンツを修正した際、その後にWYSIWYGエディタを使わずにすぐに編集完了しようすると修正が反映されないようでした。
その問題を修正するPRです。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
