### PR TITLE
Add `LastCommentActivitiesCell` and `Comments::LastCommentActivityCell`

### DIFF
--- a/app/cells/decidim/comments/last_comment_activity/show.erb
+++ b/app/cells/decidim/comments/last_comment_activity/show.erb
@@ -1,0 +1,28 @@
+<div class="activity" data-activity>
+  <div class="activity__time">
+    <%= created_at %>
+  </div>
+  <div class="activity__content">
+    <span>
+      <% if title.present? %>
+        <span>
+          <%= title_icon %>
+          <%= title %>
+        </span>
+      <% end %>
+      <a href="<%= resource_link_path %>">
+        <%= html_truncate decidim_sanitize(resource_link_text, strip_tags: true), length: max_comment_length %>
+      </a>
+    </span>
+    <% unless hide_participatory_space? %>
+      <span>
+        <%= participatory_space_link %>
+      </span>
+    <% end %>
+  </div>
+  <% if show_author? %>
+    <div class="activity__author">
+      <%= author %>
+    </div>
+  <% end %>
+</div>

--- a/app/cells/decidim/comments/last_comment_activity_cell.rb
+++ b/app/cells/decidim/comments/last_comment_activity_cell.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Comments
+    # A cell to display when a comment has been created.
+    class LastCommentActivityCell < ActivityCell
+      include CommentCellsHelper
+
+      def show
+        return unless renderable?
+
+        render
+      end
+
+      def title
+        I18n.t("decidim.comments.last_activity.new_comment")
+      end
+
+      def participatory_space
+        model.participatory_space_lazy
+      end
+
+      def participatory_space_link
+        link_to(root_commentable_title, resource_link_path)
+      end
+
+      def participatory_space_icon
+        resource_type_icon(root_commentable.class)
+      end
+
+      def hide_participatory_space? = false
+
+      def comment
+        model.resource_lazy
+      end
+
+      def max_comment_length
+        40
+      end
+    end
+  end
+end

--- a/app/cells/decidim/content_blocks/last_comment/show.erb
+++ b/app/cells/decidim/content_blocks/last_comment/show.erb
@@ -9,6 +9,6 @@
       <% end %>
   </div>
   <% valid_comments.each_slice(4) do |column_activities| %>
-    <%= cell "decidim/activities", column_activities %>
+    <%= cell "decidim/last_comment_activities", column_activities %>
   <% end %>
 </section>

--- a/app/cells/decidim/last_comment_activities/show.erb
+++ b/app/cells/decidim/last_comment_activities/show.erb
@@ -1,0 +1,5 @@
+<div class="activity__container">
+  <% activities.each do |activity| %>
+    <%= activity_cell_for(activity) %>
+  <% end %>
+</div>

--- a/app/cells/decidim/last_comment_activities_cell.rb
+++ b/app/cells/decidim/last_comment_activities_cell.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Renders a collection of activities using a different cell for
+  # each one.
+  class LastCommentActivitiesCell < Decidim::ViewModel
+    include Decidim::CardHelper
+    include Decidim::IconHelper
+    include Decidim::Core::Engine.routes.url_helpers
+
+    # Since we are rendering each activity separatedly we need to trigger
+    # BatchLoader in order to accumulate all the ids to be found later.
+    def show
+      return if activities.blank?
+
+      render
+    end
+
+    def activity_cell_for(activity)
+      opts = options.slice(:id_prefix, :hide_participatory_space).merge(
+        show_author: (context[:user] != activity.user)
+      )
+
+      cell "decidim/comments/last_comment_activity", activity, context: opts
+    end
+
+    def activities
+      @activities ||= model.map do |activity|
+        activity.organization_lazy
+        activity.resource_lazy
+        activity.participatory_space_lazy
+        activity.component_lazy
+        activity
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

`Decidim::Comments::LastCommentActivityCell#max_comment_length` で「最近のコメント」の長さを指定できるようにするため、`Decidim::Comments::LastCommentActivityCell`と`Decidim::LastCommentActivitiesCell`を追加します。

max_comment_lengthは今のところ40にしています。

（元になっているのが`Decidim::ActivitiesCell`と`Decidim::Comments::CommentActivityCell`なんですが、元のCellに変更があると適宜反映しなければならないため、ちょっとメンテナンスが面倒かも…という懸念はあります）

#### :pushpin: Related Issues
- Related to https://github.com/ayuki-joto/decidim-cfj/pull/40

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
