### PR TITLE
add `address_help` for help_text

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -76,6 +76,7 @@ ja:
           see_username: アカウントIDを見る
           sign_in: ログイン
           username_placeholder: 共創 歩
+          address_help: 例) 兵庫県加古川市加古川町2
     events:
       gamification:
         level_up:

--- a/decidim-user_extension/app/views/decidim/devise/registrations/_user_extension.html.erb
+++ b/decidim-user_extension/app/views/decidim/devise/registrations/_user_extension.html.erb
@@ -4,7 +4,7 @@
               </div>
 
               <div class="field">
-                <%= f_ext.text_field :address, label: t(:address, scope: "activemodel.attributes.user_extension"), autocomplete: 'street-address' %>
+                <%= f_ext.text_field :address, help_text: t(".address_help"), label: t(:address, scope: "activemodel.attributes.user_extension"), autocomplete: 'street-address' %>
               </div>
 
               <div class="field">


### PR DESCRIPTION
#### :tophat: What? Why?

住所の例を追加します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

<img width="660" alt="address_help" src="https://github.com/user-attachments/assets/e8f79039-379f-4db7-b71b-4513f6a42196" />

