### PR TITLE
fix: make comments_count 3

### DIFF
--- a/app/cells/decidim/content_blocks/last_comment_cell.rb
+++ b/app/cells/decidim/content_blocks/last_comment_cell.rb
@@ -63,7 +63,7 @@ module Decidim
       end
 
       def comments_to_show
-        options[:comments_count] || 16
+        options[:comments_count] || 3
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

「最近のコメント」で表示される件数を3件にします。

#### :pushpin: Related Issues
- Related to https://github.com/ayuki-joto/decidim-cfj/pull/40

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

<img width="800" alt="last_comments_3" src="https://github.com/user-attachments/assets/d3a843c4-64e5-4c0b-9624-878f24a36104" />
