### PR TITLE
fix: iframe extension

### DIFF
--- a/app/packs/src/decidim/cfj/editor/extensions/iframe/index.js
+++ b/app/packs/src/decidim/cfj/editor/extensions/iframe/index.js
@@ -1,6 +1,6 @@
 import { Node } from "@tiptap/core"
 
-const iframeAllowedDomains = ["www.youtube.com", "vimeo.com", "docs.google.com"];
+const iframeAllowedDomains = ["www.youtube.com", "www.youtube-nocookie.com", "vimeo.com", "docs.google.com", "www.slideshare.net"];
 
 const isAllowedDomain = (src) => {
   if (!src) return false;
@@ -40,6 +40,18 @@ export default Node.create({
       },
       frameborder: {
         default: 0,
+      },
+      width: {
+        default: null,
+      },
+      height: {
+        default: null,
+      },
+      style: {
+        default: null,
+      },
+      scrolling: {
+        default: null,
       },
       allowfullscreen: {
         default: this.options.allowFullscreen,

--- a/app/packs/src/decidim/editor/extensions/decidim_kit/index.js
+++ b/app/packs/src/decidim/editor/extensions/decidim_kit/index.js
@@ -35,6 +35,7 @@ export default Extension.create({
       },
       hashtag: false,
       mention: false,
+      iframe: true,
       emoji: false
     };
   },
@@ -55,7 +56,6 @@ export default Extension.create({
       OrderedList,
       CodeBlock,
       TagEdit,
-      Iframe,
       Underline
     ];
 
@@ -81,6 +81,10 @@ export default Extension.create({
 
     if (this.options.emoji !== false) {
       extensions.push(Emoji.configure(this.options.emoji));
+    }
+
+    if (this.options.iframe !== false) {
+      extensions.push(Iframe.configure(this.options.iframe));
     }
 
     return extensions;


### PR DESCRIPTION
#### :tophat: What? Why?

( https://github.com/codeforjapan/decidim-cfj/pull/645 と同じものです)

エディタのiframe拡張に対する修正です。

* attributesの追加 (width, height, style, scrolling)
* iframe拡張とyoutube拡張(iframeを使用)の両方があっても回避できるようにします。具体的にはyoutube拡張は独自のclassを使っているため、youtube拡張の方を優先して検出するように順番を変えています(iframe拡張はiframeならなんでも検出するため順番を逆にするとyoutube拡張もiframe拡張だと誤認識する)。
* iframeのsrcに使えるサイトを追加 (slideshare と youtube-nocookie)

#### :pushpin: Related Issues
- Related to https://github.com/ayuki-joto/decidim-cfj/pull/53

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
