### PR TITLE
fix: do not add comment_counts if already registered

### DIFF
--- a/config/initializers/comments_count.rb
+++ b/config/initializers/comments_count.rb
@@ -3,29 +3,37 @@
 Rails.application.config.to_prepare do
   # Add :comment_count to accountability_component's stat
   accountability_component = Decidim.find_component_manifest(:accountability)
-  accountability_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
-    results = Decidim::Accountability::FilteredResults.for(components, start_at, end_at)
-    results.sum(:comments_count)
+  if accountability_component.stats.only([:comments_count]).stats.blank?
+    accountability_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+      results = Decidim::Accountability::FilteredResults.for(components, start_at, end_at)
+      results.sum(:comments_count)
+    end
   end
 
   # Add :comment_count to blogs_component's stat
   blogs_component = Decidim.find_component_manifest(:blogs)
-  blogs_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
-    posts = Decidim::Blogs::FilteredPosts.for(components, start_at, end_at)
-    posts.sum(:comments_count)
+  if blogs_component.stats.only([:comments_count]).stats.blank?
+    blogs_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+      posts = Decidim::Blogs::FilteredPosts.for(components, start_at, end_at)
+      posts.sum(:comments_count)
+    end
   end
 
   # Add :comment_count to debates_component's stat
   debates_component = Decidim.find_component_manifest(:debates)
-  debates_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
-    debates = Decidim::Debates::FilteredDebates.for(components, start_at, end_at)
-    debates.sum(:comments_count)
+  if debates_component.stats.only([:comments_count]).stats.blank?
+    debates_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+      debates = Decidim::Debates::FilteredDebates.for(components, start_at, end_at)
+      debates.sum(:comments_count)
+    end
   end
 
   # Add :comment_count to sortitions_component's stat
   sortitions_component = Decidim.find_component_manifest(:sortitions)
-  sortitions_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
-    sortitions = Decidim::Sortitions::FilteredSortitions.for(components, start_at, end_at)
-    sortitions.sum(:comments_count)
+  if sortitions_component.stats.only([:comments_count]).stats.blank?
+    sortitions_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+      sortitions = Decidim::Sortitions::FilteredSortitions.for(components, start_at, end_at)
+      sortitions.sum(:comments_count)
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

( https://github.com/codeforjapan/decidim-cfj/pull/646 と同じものです)

開発環境で再読み込みが走るとinitializesの内容が二度実行されるため、その際にエラーになっていたのを修正するものです。
すでに登録されている場合は再登録せずにskipするようになります。

（本番環境ではそもそも通常再読み込みが発生しなさそうなので関係なさそうです）

#### :pushpin: Related Issues
- Related to https://github.com/ayuki-joto/decidim-cfj/pull/53

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
