### PR TITLE
footerのリソース欄を削除

### DIFF
--- a/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -1,16 +1,5 @@
 <%= footer_menu.render %>
 
-<nav role="navigation" aria-label="<%= t("layouts.decidim.footer.resources") %>">
-  <h2 class="h4 mb-4"><%= t("layouts.decidim.footer.resources") %></h2>
-  <ul class="space-y-4 break-inside-avoid">
-    <li class="font-semibold underline"><%= link_to t("decidim.profiles.show.activity"), decidim.last_activities_path %></li>
-    <% if Decidim.module_installed?(:meetings) %>
-      <li class="font-semibold underline"><%= link_to t("decidim.pages.home.extended.meetings"), Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path %></li>
-    <% end %>
-    <li class="font-semibold underline"><%= link_to t("layouts.decidim.footer.download_open_data"), decidim.open_data_download_path %></li>
-  </ul>
-</nav>
-
 <nav role="navigation" aria-label="<%= t("layouts.decidim.user_menu.profile") %>">
   <h2 class="h4 mb-4"><%= t("layouts.decidim.user_menu.profile") %></h2>
   <ul class="space-y-4 break-inside-avoid">

--- a/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -1,0 +1,29 @@
+<%= footer_menu.render %>
+
+<nav role="navigation" aria-label="<%= t("layouts.decidim.footer.resources") %>">
+  <h2 class="h4 mb-4"><%= t("layouts.decidim.footer.resources") %></h2>
+  <ul class="space-y-4 break-inside-avoid">
+    <li class="font-semibold underline"><%= link_to t("decidim.profiles.show.activity"), decidim.last_activities_path %></li>
+    <% if Decidim.module_installed?(:meetings) %>
+      <li class="font-semibold underline"><%= link_to t("decidim.pages.home.extended.meetings"), Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path %></li>
+    <% end %>
+    <li class="font-semibold underline"><%= link_to t("layouts.decidim.footer.download_open_data"), decidim.open_data_download_path %></li>
+  </ul>
+</nav>
+
+<nav role="navigation" aria-label="<%= t("layouts.decidim.user_menu.profile") %>">
+  <h2 class="h4 mb-4"><%= t("layouts.decidim.user_menu.profile") %></h2>
+  <ul class="space-y-4 break-inside-avoid">
+    <% if current_user %>
+      <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.configuration"), decidim.account_path %></li>
+      <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.public_profile"), decidim.profile_path(current_user.nickname) %></li>
+      <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.notifications"), decidim.notifications_path %></li>
+      <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.conversations"), decidim.conversations_path %></li>
+    <% else %>
+      <% if current_organization.sign_up_enabled? %>
+        <li class="font-semibold underline"><%= link_to t("layouts.decidim.footer.sign_up"), decidim.new_user_registration_path %></li>
+      <% end %>
+      <li class="font-semibold underline"><%= link_to t("layouts.decidim.footer.log_in"), decidim.new_user_session_path %></li>
+    <% end %>
+  </ul>
+</nav>


### PR DESCRIPTION
#### :tophat: What? Why?

footerのうち「リソース」欄を表示させないようにする修正です。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

以下のようになります。

<img width="800" alt="footer" src="https://github.com/user-attachments/assets/7389dec6-952b-4ca2-902f-e68106a5fdc9" />

