### PR TITLE
feat: add LINE as SNS

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -518,3 +518,13 @@ Rails.application.config.to_prepare do
   end
 end
 Decidim.icons.register(name: "line", icon: "line-fill", category: "system", description: "", engine: :core)
+
+## Register LINE as SNS
+Decidim.register_social_share_service("LINE") do |service|
+  service.icon = "line-fill"
+  service.icon_color = "#06C755"
+  service.share_uri = "https://social-plugins.line.me/lineit/share?url=%{url}&text=%{title}"
+end
+
+## Share buttons on SNS
+Decidim.social_share_services = %w(X Facebook LINE)


### PR DESCRIPTION
#### :tophat: What? Why?

共有ボタンをX, Facebook, LINEの3つにします。
（LINEの共有用URLはこれでいいんでしたっけ…？）

参考: https://developers.line.biz/ja/docs/line-social-plugins/install-guide/using-line-share-buttons/

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

<img width="990" alt="sns-share" src="https://github.com/user-attachments/assets/0f02c105-bfbc-4ab1-9707-75b5045f8364" />

