### PR TITLE
参加型プロセスと参加スペースの「お知らせ」コンテンツブロックをデフォルトで有効にする

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -518,3 +518,9 @@ Rails.application.config.to_prepare do
   end
 end
 Decidim.icons.register(name: "line", icon: "line-fill", category: "system", description: "", engine: :core)
+
+Rails.application.config.to_prepare do
+  # make some content_blocks as default
+  Decidim.content_blocks.for(:assembly_homepage).find { |block| block.name == :announcement }.default!
+  Decidim.content_blocks.for(:participatory_process_homepage).find { |block| block.name == :announcement }.default!
+end


### PR DESCRIPTION
#### :tophat: What? Why?

新しく参加型プロセスや参加スペースを作った際、「お知らせ」コンテンツブロックがデフォルトで有効になっている修正します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

新しい参加スペースを作り、「ランディングページ」を開くと以下のようになります。

<img width="800" alt="landing-page" src="https://github.com/user-attachments/assets/e47c534b-ab0b-40de-a77e-e87c077365c2" />
