### PR TITLE
omniauth-dcp-loginのバージョンをv1.3.0にあげた

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "deface"
 gem "image_processing"
 gem "newrelic_rpm"
 
-gem "omniauth-cityos-dcp", git: "https://github.com/TheDesignium/omniauth-cityos-dcp.git", tag: "v1.2.2"
+gem "omniauth-cityos-dcp", git: "https://github.com/TheDesignium/omniauth-cityos-dcp.git", tag: "v1.3.0"
 gem "omniauth-line_login", path: "omniauth-line_login"
 gem "omniauth-rails_csrf_protection"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/TheDesignium/omniauth-cityos-dcp.git
-  revision: ae135dc3f01f06a13ec4d24c8327e19b10cf701f
-  tag: v1.2.2
+  revision: 0fd1f02e17f0444d798cc5aff4fd8fadbc4a8313
+  tag: v1.3.0
   specs:
     omniauth-cityos-dcp (0.1.0)
       decidim (>= 0.28.0)
@@ -953,4 +953,4 @@ RUBY VERSION
    ruby 3.1.1p18
 
 BUNDLED WITH
-   2.4.21
+   2.3.7


### PR DESCRIPTION
#### :tophat: What? Why?
以前cookieを使うようにしたバージョンを取り込んでいなかったので、バージョンをあげました
確認をお願いします

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
