### PR TITLE
fix: make `auto_save_forms` disable in DecidimAwesome

### DIFF
--- a/config/initializers/decidim_awesome.rb
+++ b/config/initializers/decidim_awesome.rb
@@ -2,4 +2,5 @@
 
 Decidim::DecidimAwesome.configure do |config|
   config.admin_accountability = []
+  config.auto_save_forms = false
 end


### PR DESCRIPTION
#### :tophat: What? Why?

`Decidim::DecidimAwesome`の設定で、「ローカルストレージにデータを保存しました」等のメッセージをデフォルトで出さないようにします（というか、ローカルストレージへのオートセーブをオフにします）。

管理画面のDecidimAwesome内、「調査＆フォーム 」のところにある「ローカルストレージにフォームを自動保存する」のチェックボックスをいれるとオートセーブが有効になります。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
