### PR TITLE
fix: link to last comments

### DIFF
--- a/app/cells/decidim/content_blocks/last_comment/show.erb
+++ b/app/cells/decidim/content_blocks/last_comment/show.erb
@@ -3,7 +3,7 @@
     <h2 class="home__section-title">
       <%= t("decidim.content_blocks.last_comment.title") %>
     </h2>
-    <%= link_to last_activities_path, class: "button button__sm button__text-secondary" do %>
+    <%= link_to last_activities_path(filter: { with_resource_type: 'Decidim::Comments::Comment' }), class: "button button__sm button__text-secondary" do %>
         <%= t("view_all", scope: "decidim.content_blocks.last_comment") %>
         <%= icon "arrow-right-line", class: "fill-current" %>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

最近のコメントにある「すべて表示」のリンク先を、「最近のアクティビティ」のトップページではなくコメントのフィルタがかかっている状態のページに変更します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

リンク先は以下のようになります。

<img width="800" alt="link" src="https://github.com/user-attachments/assets/71e7b365-c01b-4c86-a4b0-8850280c0fae" />

