### PR TITLE
「一部のみ表示」ボタンを押した際に適度にスクロールさせる

### DIFF
--- a/app/packs/entrypoints/decidim_cfj_participatory_processes.js
+++ b/app/packs/entrypoints/decidim_cfj_participatory_processes.js
@@ -1,0 +1,3 @@
+import initializeScroll from "src/decidim/cfj/accordion-scroll"
+
+document.addEventListener("DOMContentLoaded", initializeScroll);

--- a/app/packs/src/decidim/cfj/accordion-scroll.js
+++ b/app/packs/src/decidim/cfj/accordion-scroll.js
@@ -1,0 +1,28 @@
+export default () => {
+  const accordions = document.querySelectorAll('[data-component="accordion"]');
+
+  accordions.forEach(accordion => {
+    const button = accordion.querySelector('[data-controls]');
+
+    if (button) {
+      button.addEventListener('click', () => {
+        const isExpanded = button.getAttribute('aria-expanded') === 'false';
+
+        if (!isExpanded) {
+          let accordionTop;
+          if (accordion.parentElement) {
+            accordionTop = accordion.parentElement.offsetTop;
+          } else {
+            accordionTop = accordion.offsetTop;
+          }
+
+          window.scrollTo({
+            top: accordionTop,
+            behavior: 'instant'
+          });
+        }
+      });
+    }
+  });
+};
+

--- a/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -14,6 +14,8 @@
   )
 %>
 
+<%= append_javascript_pack_tag "decidim_cfj_participatory_processes" %>
+
 <%# NOTE: this elements goes outside of the .participatory-space__container block %>
 <% if current_participatory_space.private_space? %>
   <section class="participatory-space__block-reference alert">

--- a/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -1,0 +1,39 @@
+<% add_decidim_meta_tags({
+                           image_url: current_participatory_space.attached_uploader(:hero_image).url,
+                           description: translated_attribute(current_participatory_space.short_description),
+                           url: participatory_process_url(current_participatory_space),
+                           twitter_handler: current_organization.twitter_handler
+                         }) %>
+
+<%
+  edit_link(
+    resource_locator(current_participatory_space).edit,
+    :update,
+    :process,
+    process: current_participatory_space
+  )
+%>
+
+<%# NOTE: this elements goes outside of the .participatory-space__container block %>
+<% if current_participatory_space.private_space? %>
+  <section class="participatory-space__block-reference alert">
+    <%= t("private_space", scope: "decidim.participatory_processes.show") %>
+  </section>
+<% end %>
+
+<div class="participatory-space__container">
+
+  <%= participatory_space_floating_help %>
+  <%= cell "decidim/participatory_processes/process_step", current_participatory_space, display_steps: params[:display_steps] %>
+
+  <% active_content_blocks.each do |content_block| %>
+    <% next unless content_block.manifest %>
+
+    <%= cell content_block.manifest.cell, content_block %>
+  <% end %>
+
+</div>
+
+<section class="participatory-space__block-reference">
+  <%= resource_reference(current_participatory_space) %>
+</section>


### PR DESCRIPTION
#### :tophat: What? Why?

参加型プロセスのページでアコーディオンを使って開閉しているボタンについて、閉じるときに適度なスクロールを行うよう修正します。

閉じるボタンでスクロールするためのJSは適当にHTMLに貼り付けるよりちゃんと別ファイルに切り分けておいた方がいいよなあ…と思い、`append_javascript_pack_tag`でJSを埋め込むようにしています。
そのため `app/views/decidim/participatory_processes/participatory_processes/show.html.erb` をコピーしています。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
