### PR TITLE
fix: remove invalid characters in file_type

### DIFF
--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -157,6 +157,23 @@ Rails.application.config.to_prepare do
     end
   end
 
+  ## fix `Decidim::Attachment#file_type`
+  module DecidimAttachmentFiletypePatch
+    def file_type
+      url&.split(".")&.last&.downcase&.gsub(/[^A-Za-z0-9].*/, "")
+    end
+  end
+
+  # force to autoload `` in decidim-core
+  Decidim::Attachment # rubocop:disable Lint/Void
+
+  # override `UserAnswersSerializer#hash_for`
+  module Decidim
+    class Attachment
+      prepend DecidimAttachmentFiletypePatch
+    end
+  end
+
   # Fix I18n.transliterate()
   I18n.config.backend.instance_eval do
     @transliterators[:ja] = I18n::Backend::Transliterator.get(->(string) { string })


### PR DESCRIPTION
#### :tophat: What? Why?

添付ファイルの拡張子（？）を抽出する際、英数字以外の文字が来たらその文字以降を落とすようにします。
（そもそもファイルに適切な拡張子がついているとは限らないので、限界があります…）

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
