### PR TITLE
メニュー左側に表示される注目のプロセスを修正

### DIFF
--- a/app/helpers/decidim/menu_helper.rb
+++ b/app/helpers/decidim/menu_helper.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This module includes helpers to manage menus in layout
+  module MenuHelper
+    # Public: Returns the main menu presenter object
+    def main_menu
+      @main_menu ||= ::Decidim::MenuPresenter.new(
+        :menu,
+        self,
+        element_class: "main-nav__link",
+        active_class: "main-nav__link--active",
+        label: t("layouts.decidim.header.main_menu")
+      )
+    end
+
+    def main_menu_modules
+      @main_menu ||= ::Decidim::MenuPresenter.new(
+        :menu,
+        self,
+        element_class: "main-nav__link-modules",
+        active_class: "main-nav__link-modules--active",
+        label: t("layouts.decidim.header.main_menu")
+      )
+    end
+
+    # Public: Returns the user menu presenter object
+    def user_menu
+      @user_menu ||= ::Decidim::InlineMenuPresenter.new(
+        :user_menu,
+        self,
+        element_class: "tabs-title",
+        active_class: "is-active",
+        label: t("layouts.decidim.user_menu.title")
+      )
+    end
+
+    def breadcrumb_root_menu
+      @breadcrumb_root_menu ||= ::Decidim::BreadcrumbRootMenuPresenter.new(
+        :menu,
+        self,
+        container_options: { class: "menu-bar__main-dropdown__menu" }
+      )
+    end
+
+    def footer_menu
+      @footer_menu ||= ::Decidim::FooterMenuPresenter.new(
+        :menu,
+        self,
+        element_class: "font-semibold underline",
+        active_class: "is-active",
+        container_options: { class: "space-y-4 break-inside-avoid" },
+        label: t("layouts.decidim.footer.decidim_title")
+      )
+    end
+
+    def menu_highlighted_participatory_process
+      return if current_user.blank? && current_organization&.force_users_to_authenticate_before_access_organization
+
+      @menu_highlighted_participatory_process ||= (
+        # The queries already include the order by weight
+        Decidim::ParticipatoryProcesses::OrganizationParticipatoryProcesses.new(current_organization) |
+        Decidim::ParticipatoryProcesses::PromotedParticipatoryProcesses.new
+      ).first
+    end
+
+    def home_content_block_menu
+      @home_content_block_menu ||= ::Decidim::MenuPresenter.new(
+        :home_content_block_menu,
+        self,
+        element_class: "main-nav__link",
+        active_class: "main-nav__link--active",
+        label: t("layouts.decidim.header.main_menu")
+      )
+    end
+  end
+end

--- a/app/helpers/decidim/menu_helper.rb
+++ b/app/helpers/decidim/menu_helper.rb
@@ -59,8 +59,8 @@ module Decidim
 
       @menu_highlighted_participatory_process ||= (
         # The queries already include the order by weight
-        Decidim::ParticipatoryProcesses::OrganizationParticipatoryProcesses.new(current_organization) |
-        Decidim::ParticipatoryProcesses::PromotedParticipatoryProcesses.new
+        Decidim::ParticipatoryProcesses::OrganizationParticipatoryProcesses.new(current_organization).query.visible_for(current_user) |
+        Decidim::ParticipatoryProcesses::PromotedParticipatoryProcesses.new.query.visible_for(current_user)
       ).first
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

大きなドロップダウンメニューの左側に参加型プロセスを表示する機能がありますが、表示されるプロセスの条件を制限します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
