### PR TITLE
fix: Prevent error when `model.proposal_state` is nil

### DIFF
--- a/app/cells/decidim/proposals/proposal_metadata_cell.rb
+++ b/app/cells/decidim/proposals/proposal_metadata_cell.rb
@@ -22,7 +22,7 @@ module Decidim
         elsif model.emendation?
           { text: content_tag(:span, humanize_proposal_state(state), class: "label #{state_class}") }
         else
-          { text: content_tag(:span, translated_attribute(model.proposal_state&.title), class: "label", style: model.proposal_state.css_style) }
+          { text: content_tag(:span, translated_attribute(model.proposal_state&.title), class: "label", style: model.proposal_state&.css_style) }
         end
       end
 

--- a/app/cells/decidim/proposals/proposal_metadata_cell.rb
+++ b/app/cells/decidim/proposals/proposal_metadata_cell.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # This cell renders metadata for an instance of a Proposal
+    class ProposalMetadataCell < Decidim::CardMetadataCell
+      include Decidim::Proposals::ApplicationHelper
+
+      delegate :state, to: :model
+
+      def initialize(*)
+        super
+
+        @items.prepend(*proposal_items)
+      end
+
+      def state_item
+        return if state.blank? || @options.fetch(:skip_state, false)
+
+        if model.withdrawn?
+          { text: content_tag(:span, humanize_proposal_state(:withdrawn), class: "label alert") }
+        elsif model.emendation?
+          { text: content_tag(:span, humanize_proposal_state(state), class: "label #{state_class}") }
+        else
+          { text: content_tag(:span, translated_attribute(model.proposal_state&.title), class: "label", style: model.proposal_state.css_style) }
+        end
+      end
+
+      def state_class
+        return "alert" if model.withdrawn?
+
+        case state
+        when "accepted"
+          "success"
+        when "rejected"
+          "alert"
+        when "evaluating"
+          "warning"
+        else
+          "muted"
+        end
+      end
+
+      private
+
+      def proposal_items
+        [coauthors_item, comments_count_item, endorsements_count_item, state_item, emendation_item]
+      end
+
+      def proposal_items_for_map
+        [coauthors_item_for_map, comments_count_item, endorsements_count_item, state_item, emendation_item].compact_blank.map do |item|
+          {
+            text: item[:text].to_s.html_safe,
+            icon: item[:icon].present? ? icon(item[:icon]).html_safe : nil
+          }
+        end
+      end
+
+      def coauthors_item_for_map
+        presented_author = official? ? Decidim::Proposals::OfficialAuthorPresenter.new : present(resource.identities.first)
+
+        {
+          text: presented_author.name,
+          icon: "account-circle-line"
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

v0.29.2でエラーが出る場合があったので修正します。

#### :pushpin: Related Issues
- Related to https://github.com/codeforjapan/decidim-cfj/pull/684

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
