### PR TITLE
fix: do not define names of organization

### DIFF
--- a/spec/mailers/notifications_digest_mailer_spec.rb
+++ b/spec/mailers/notifications_digest_mailer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module Decidim
   describe NotificationsDigestMailer do
-    let(:organization) { create(:organization, name: "Test Organization") }
+    let(:organization) { create(:organization) }
     let(:user) { create(:user, :admin, organization:, locale: "ja", notifications_sending_frequency: "real_time") }
     let(:decidim) { Decidim::Core::Engine.routes.url_helpers }
 

--- a/spec/mailers/reported_mailer_spec.rb
+++ b/spec/mailers/reported_mailer_spec.rb
@@ -14,7 +14,11 @@ module Decidim
     let(:decidim) { Decidim::Core::Engine.routes.url_helpers }
 
     before do
-      reportable.coauthorships.first.author.update!(name: "O.Higgins")
+      if reportable.coauthorships.first.author.is_a?(Decidim::Organization)
+        reportable.coauthorships.first.author.update!(name: { en: "O'Higgins" })
+      else
+        reportable.coauthorships.first.author.update!(name: "O'Higgins")
+      end
     end
 
     around do |example|

--- a/spec/mailers/reported_mailer_spec.rb
+++ b/spec/mailers/reported_mailer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module Decidim
   describe ReportedMailer do
-    let(:organization) { create(:organization, name: "Test Organization") }
+    let(:organization) { create(:organization) }
     let(:user) { create(:user, :admin, organization:, locale: "ja") }
     let(:component) { create(:component, organization:) }
     let(:reportable) { create(:proposal, title: Decidim::Faker::Localized.sentence, body: Decidim::Faker::Localized.paragraph(sentence_count: 3)) }


### PR DESCRIPTION
#### :tophat: What? Why?

テストでのDecidim::OrganizationのFactoryBotについて、nameは指定せず自動生成させるよう修正します。

#### :pushpin: Related Issues
- Related to https://github.com/codeforjapan/decidim-cfj/pull/684

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
