### PR TITLE
fix: comment sorting persistence during AJAX polling

### DIFF
--- a/app/views/decidim/comments/comments/reload.js.erb
+++ b/app/views/decidim/comments/comments/reload.js.erb
@@ -8,7 +8,8 @@
   var commentsHtml = '<%== j(inline_comments_for(commentable, order:).inline).strip %>';
   $(".loading-comments").addClass("hidden");
   $comments.html(commentsHtml);
-  component.lastCommentId = null;
+
+  component.order = <%== order.to_json %>;
 
   // Re-mount the component
   component.mountComponent();

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -52,7 +52,7 @@ Rails.application.config.to_prepare do
           params_order = params.fetch(:order, nil)
           reload_request = params.fetch(:reload, nil).present?
           if params_order
-            if reload_request && cookies[Decidim.config.consent_cookie_name].present?
+            if reload_request && cookies[Decidim.config.consent_cookie_name].present? # rubocop:disable Style/IfUnlessModifier
               cookies["comment_default_order"] = params_order
             end
             params_order

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -51,9 +51,10 @@ Rails.application.config.to_prepare do
         def order
           params_order = params.fetch(:order, nil)
           reload_request = params.fetch(:reload, nil).present?
-
-          if reload_request && params_order.present?
-            cookies["comment_default_order"] = params_order if cookies[Decidim.config.consent_cookie_name].present?
+          if params_order
+            if reload_request && cookies[Decidim.config.consent_cookie_name].present?
+              cookies["comment_default_order"] = params_order
+            end
             params_order
           elsif cookies["comment_default_order"].present? && cookies[Decidim.config.consent_cookie_name].present?
             cookies["comment_default_order"]

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -74,7 +74,7 @@ Rails.application.config.to_prepare do
             resource,
             machine_translations: machine_translations_toggled?,
             single_comment: params.fetch("commentId", nil),
-            order: options[:order] || params["orderable"] || cookies["comment_default_order"],
+            order: options[:order] || cookies["comment_default_order"],
             polymorphic: options[:polymorphic]
           )
         end


### PR DESCRIPTION
#### :tophat: What? Why?

だいたい良さそうでしたが少しだけ変更します。

* reload.js.erbですが、やりたいことは設定したorderをちゃんとコンポーネントにも伝える、ということだったので直接代入するようにしました。あと`unmountComponent`したときにlastCommentIdを初期化するはcomments.component.js側でやっているのでreload.js.erbでは不要そうです。
* `CommentsController#order`の方は、クッキーを上書きするのがreloadのときのみにしたいわけで、orderの返す値としてはparams_orderがあればparams_orderを返すのが良さそうです。というわけでその条件だけ修正しています。
* それとは別に、`params["orderable"]`はもう使われていないので消しておきます。

#### :pushpin: Related Issues
- Related to https://github.com/codeforjapan/decidim-cfj/pull/719

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
