### PR TITLE
fix: errors in db:migrate with `unscoped`

### DIFF
--- a/db/migrate/20201019071957_fix_proposals_data_to_ensure_title_and_body_are_hashes.decidim_proposals.rb
+++ b/db/migrate/20201019071957_fix_proposals_data_to_ensure_title_and_body_are_hashes.decidim_proposals.rb
@@ -6,7 +6,7 @@ class FixProposalsDataToEnsureTitleAndBodyAreHashes < ActiveRecord::Migration[5.
     reset_column_information
 
     PaperTrail.request(enabled: false) do
-      Decidim::Proposals::Proposal.find_each do |proposal|
+      Decidim::Proposals::Proposal.unscoped.find_each do |proposal|
         next if proposal.title.is_a?(Hash) && proposal.body.is_a?(Hash)
 
         author = proposal.coauthorships.first.author

--- a/db/migrate/20201019071958_fix_proposals_data.decidim_proposals.rb
+++ b/db/migrate/20201019071958_fix_proposals_data.decidim_proposals.rb
@@ -22,7 +22,7 @@ class FixProposalsData < ActiveRecord::Migration[5.2]
 
   def up
     PaperTrail.request(enabled: false) do
-      Proposal.find_each do |proposal|
+      Proposal.unscoped.find_each do |proposal|
         next if proposal.title.is_a?(Hash) && proposal.body.is_a?(Hash)
 
         coauthorship = Coauthorship.order(:id).find_by(coauthorable_type: "Decidim::Proposals::Proposal", coauthorable_id: proposal.id)


### PR DESCRIPTION
#### :tophat: What? Why?

v0.30.xでdb:migrateが失敗するのを修正します。

原因ですが、どうもデフォルトスコープを変更する`Decidim::SoftDeletable`が導入されたため、過去のmigrationを実行する場合にもこれが適用されてしまうためのようです。
そのため、`unscoped`を追加してデフォルトスコープを無視するようにします。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
