### PR TITLE
fix: remove `Decidim.max_results_options`

### DIFF
--- a/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
+++ b/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
@@ -1,3 +1,0 @@
-<% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, Decidim.max_results_options, prompt: "", label: %>
-<% end %>

--- a/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
+++ b/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
@@ -1,3 +1,0 @@
-<% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, Decidim.max_results_options, prompt: "", label: %>
-<% end %>

--- a/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
+++ b/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
@@ -1,3 +1,0 @@
-<% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, Decidim.max_results_options, prompt: "", label: %>
-<% end %>

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -128,12 +128,6 @@ Rails.application.config.to_prepare do
     @transliterators[:en] = I18n::Backend::Transliterator.get(->(string) { string })
   end
 
-  module Decidim
-    config_accessor :max_results_options
-  end
-
-  Decidim.max_results_options = [6, 9, 12, 15]
-
   # Insert `app/views` into Cell::ViewModel.view_paths to load application's views
   Cell::ViewModel.view_paths.insert(1, Rails.root.join("app/views"))
 


### PR DESCRIPTION
#### :tophat: What? Why?

プルダウンの選択肢を外部から注入するための`Decidim.max_results_options`を削除します。

以前はプルダウンから選択する方式だったのが任意の数値入力に変わったので、そのためのオーバーライドを消します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

Before

<img width="871" height="293" alt="old-admin-form" src="https://github.com/user-attachments/assets/93b13798-fd17-436d-ad75-fd1f2414bef5" />


After

<img width="883" height="214" alt="new-admin-form" src="https://github.com/user-attachments/assets/c7adcb77-b830-4348-a227-52d6f4920f93" />
