### PR TITLE
Fix `ParticipatorySpaceLastActivityCell`

### DIFF
--- a/app/cells/decidim/content_blocks/participatory_space_last_activity_cell.rb
+++ b/app/cells/decidim/content_blocks/participatory_space_last_activity_cell.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentBlocks
+    class ParticipatorySpaceLastActivityCell < BaseCell
+      def render_recent_avatars
+        return if last_activities_users.blank?
+
+        render :recent_avatars
+      end
+
+      def participants_count
+        @participants_count ||= activities_query.select(:decidim_user_id).distinct.count
+      end
+
+      def activities_query
+        @activities_query ||= Decidim::ParticipatorySpaceLastActivity.new(resource).query
+      end
+
+      private
+
+      def ordered_users_with_activities
+        @ordered_users_with_activities ||=
+          Decidim::ParticipatorySpaceLastActivity
+          .new(resource).query
+          .where.not(user: nil)
+          .select("decidim_user_id, MAX(decidim_action_logs.created_at)")
+          .group("decidim_user_id")
+          .reorder("MAX(decidim_action_logs.created_at) DESC")
+      end
+
+      def last_activities_users
+        @last_activities_users ||= ordered_users_with_activities.limit(max_last_activity_users).map(&:user)
+      end
+
+      def max_last_activity_users
+        model.settings.try(:max_last_activity_users) || Decidim.default_max_last_activity_users
+      end
+
+      def hide_participatory_space = true
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

参加スペースのランディングページに「最近のアクティビティ」を追加した際、private等でも表示できる修正します。

基本的にはユーザーの情報を渡さずに「最近のアクティビティ」を表示させていたものについて、ユーザーの情報を渡して表示させることで変更するものです。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

Before:

<img width="1221" height="151" alt="last_activity" src="https://github.com/user-attachments/assets/76d55cbb-daab-4ae2-8bdb-c3801fe43271" />

After:

<img width="1217" height="237" alt="last_activity_new" src="https://github.com/user-attachments/assets/8e25cd1b-420b-4015-a6f9-3697bddb2cea" />

