### PR TITLE
fix: i18n for `taxonomy_filters_selector`

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -35,6 +35,11 @@ ja:
       organization_appearance:
         form:
           mobile_logo_help: "モバイル版で表示されるロゴ画像です。推奨サイズ: 360x120px"
+      taxonomy_filters_selector:
+        new:
+          items_count: "%{count}個の項目"
+        show:
+          items_count: "%{count}個の項目"
     amendments:
       amendable:
         button: '修正'


### PR DESCRIPTION
#### :tophat: What? Why?

分類フィルタの個数の表示を修正します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

Before:

<img width="884" height="242" alt="before" src="https://github.com/user-attachments/assets/fe279863-f4f7-4fe9-aab7-0dda72bc372e" />

After:

<img width="868" height="250" alt="after" src="https://github.com/user-attachments/assets/4519af31-b063-44f6-9c4e-26ce678d98ed" />
