### PR TITLE
fix: improve translation of taxonomy filter internal_name

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,6 +18,8 @@ ja:
       question:
         origin_title: 起案者
         origin_url: 元のURL
+      taxonomy_filter:
+        internal_name: 管理用ラベル
       user_extension:
         address: 住所
         birth_year: 生年(西暦)
@@ -35,6 +37,9 @@ ja:
       organization_appearance:
         form:
           mobile_logo_help: "モバイル版で表示されるロゴ画像です。推奨サイズ: 360x120px"
+      taxonomy_filter:
+        table:
+          internal_name: 管理用ラベル
     amendments:
       amendable:
         button: '修正'


### PR DESCRIPTION
#### :tophat: What? Why?

(PRのターゲットを差し替えます)
分類フィルターの`内部ラベル`を`管理用ラベル`に変更します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

<img width="454" height="216" alt="internal_name" src="https://github.com/user-attachments/assets/f931f081-adc6-4164-a9d2-84cb35e7db0d" />
