### PR TITLE
feat: add tasks `decidim:taxonomy:*`

### DIFF
--- a/lib/decidim/cfj/taxonomy_flatten_constants.rb
+++ b/lib/decidim/cfj/taxonomy_flatten_constants.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Cfj
+    module TaxonomyFlattenConstants
+      # Intermediate level prefix patterns used by the category migration tool.
+      # "参加スペース:" for assemblies, "参加型プロセス:" for participatory processes, etc.
+      INTERMEDIATE_PREFIXES = /\A(参加スペース|参加型プロセス|Assembly|Participatory process|Conference|Initiative): /
+    end
+  end
+end

--- a/lib/decidim/cfj/taxonomy_flattener.rb
+++ b/lib/decidim/cfj/taxonomy_flattener.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require "decidim/cfj/taxonomy_flatten_constants"
+
+module Decidim
+  module Cfj
+    class TaxonomyFlattener
+      attr_reader :issues
+
+      def initialize(organization, logger: Rails.logger)
+        @organization = organization
+        @locale = organization.default_locale
+        @logger = logger
+        @issues = []
+      end
+
+      def check!
+        @issues = []
+        Checker.new(@organization, @locale, @logger, @issues).run
+      end
+
+      def flatten!
+        @issues = []
+        Executor.new(@organization, @locale, @logger, @issues).run
+      end
+
+      # 共通基盤: クエリ・走査・issue追跡
+      class Base
+        include TaxonomyFlattenConstants
+
+        def initialize(organization, locale, logger, issues)
+          @organization = organization
+          @locale = locale
+          @logger = logger
+          @issues = issues
+        end
+
+        private
+
+        def add_issue(level, message, detail: nil)
+          @issues << { level: level, message: message }
+          tag = level == :error ? "ERROR" : "WARNING"
+          @logger.info "    [#{tag}] #{message}"
+          @logger.info "            #{detail}" if detail
+        end
+
+        def prepare_roots
+          category_roots = find_category_roots
+          if category_roots.empty?
+            @logger.info "  No category root taxonomy found. Nothing to flatten."
+            return nil
+          end
+          [category_roots, build_collision_map(category_roots)]
+        end
+
+        def each_intermediate(category_roots)
+          category_roots.each do |old_root|
+            @logger.info "  Category root: #{old_root.name[@locale]} (id: #{old_root.id})"
+            intermediates = old_root.children.to_a
+            if intermediates.empty?
+              @logger.info "    No intermediate levels. Skipping."
+              next
+            end
+            intermediates.each { |intermediate| yield(old_root, intermediate) }
+          end
+        end
+
+        def find_category_roots
+          categories_title = I18n.t("decidim.admin.categories.index.categories_title", locale: @locale, default: "Categories")
+          @organization.taxonomies.roots.select do |root|
+            name = root.name[@locale]
+            name&.start_with?("~ カテゴリ") ||
+              name&.start_with?("~ #{categories_title}")
+          end
+        end
+
+        def compute_new_root_name(name)
+          name.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
+        end
+
+        def build_collision_map(category_roots)
+          map = Hash.new { |hash, key| hash[key] = [] }
+          category_roots.each do |old_root|
+            old_root.children.each do |intermediate|
+              new_root_name_value = compute_new_root_name(intermediate.name[@locale].to_s)
+              map[new_root_name_value] << intermediate
+            end
+          end
+          map
+        end
+
+        def find_filters_for(old_root, intermediate)
+          old_root.taxonomy_filters.select do |f|
+            f.internal_name[@locale] == intermediate.name[@locale]
+          end
+        end
+
+        def find_existing_root(new_root_name_value)
+          @organization.taxonomies.roots.find_by("name->>? = ?", @locale, new_root_name_value)
+        end
+
+        def report_collisions(collision_map)
+          duplicated = collision_map.select { |_name, intermediates| intermediates.size > 1 }
+          duplicated.each do |new_name, intermediates|
+            names = intermediates.map { |i| "#{i.name[@locale]} (id: #{i.id})" }.join(", ")
+            add_issue(:error, "Duplicate new root name: \"#{new_name}\"",
+                      detail: "Colliding intermediates: #{names}")
+          end
+          duplicated
+        end
+      end
+
+      # read-only分析
+      class Checker < Base
+        def run
+          result = prepare_roots
+          return true unless result
+
+          category_roots, collision_map = result
+          each_intermediate(category_roots) { |old_root, intermediate| check_intermediate(old_root, intermediate) }
+          report_collisions(collision_map)
+
+          @issues.empty?
+        end
+
+        private
+
+        def check_intermediate(old_root, intermediate)
+          new_root_name_value = compute_new_root_name(intermediate.name[@locale].to_s)
+
+          unless intermediate.name[@locale]&.match?(INTERMEDIATE_PREFIXES)
+            add_issue(:warning, "Intermediate \"#{intermediate.name[@locale]}\" (id: #{intermediate.id}) does not match expected prefix pattern",
+                      detail: "New root name may be unexpected: \"#{new_root_name_value}\"")
+          end
+
+          existing = find_existing_root(new_root_name_value)
+          if existing
+            add_issue(:error, "New root name \"#{new_root_name_value}\" already exists (id: #{existing.id})",
+                      detail: "This would cause a conflict. Resolve before running flatten.")
+          end
+
+          filters = find_filters_for(old_root, intermediate)
+          if filters.empty?
+            add_issue(:warning, "No TaxonomyFilter found matching intermediate \"#{intermediate.name[@locale]}\"",
+                      detail: "Filter items and component assignments may be lost.")
+          end
+
+          categories = intermediate.children
+          @logger.info "    Intermediate: #{intermediate.name[@locale]} (id: #{intermediate.id})"
+          @logger.info "      -> New root: #{new_root_name_value}"
+          @logger.info "      Categories to move: #{categories.count}"
+          categories.each do |cat|
+            @logger.info "        - #{cat.name[@locale]} (id: #{cat.id}, subcategories: #{cat.children.count})"
+          end
+          @logger.info "      Filters to move: #{filters.size}"
+          filters.each do |f|
+            @logger.info "        - #{f.internal_name[@locale]} (id: #{f.id}, items: #{f.filter_items.count}, components: #{f.components_count})"
+          end
+        end
+      end
+
+      # DB変更の実行
+      class Executor < Base
+        def run
+          result = prepare_roots
+          return unless result
+
+          category_roots, collision_map = result
+          unless report_collisions(collision_map).empty?
+            @logger.error "  Aborting flatten for this organization. Resolve naming collisions and rerun."
+            return
+          end
+
+          each_intermediate(category_roots) { |old_root, intermediate| flatten_intermediate(old_root, intermediate) }
+          category_roots.each { |old_root| cleanup_old_root(old_root) }
+          reset_counters
+          @logger.info "  Done."
+        end
+
+        private
+
+        def flatten_intermediate(old_root, intermediate)
+          @logger.info "    Processing intermediate: #{intermediate.name[@locale]} (id: #{intermediate.id})"
+
+          new_root_name = intermediate.name.transform_values { |name| name.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ") }
+
+          existing = find_existing_root(new_root_name[@locale])
+          if existing
+            add_issue(:error, "Root taxonomy \"#{new_root_name[@locale]}\" already exists (id: #{existing.id}). Skipping.")
+            return
+          end
+
+          new_root = Decidim::Taxonomy.create!(
+            name: new_root_name,
+            organization: @organization,
+            weight: @organization.taxonomies.roots.count
+          )
+          @logger.info "    Created new root: #{new_root.name[@locale]} (id: #{new_root.id})"
+
+          move_categories(intermediate, new_root)
+          move_filters(old_root, intermediate, new_root)
+          cleanup_intermediate(intermediate)
+        end
+
+        def move_categories(intermediate, new_root)
+          intermediate.children.to_a.each do |category|
+            category.update!(parent: new_root)
+            @logger.info "      Moved category: #{category.name[@locale]} (id: #{category.id})"
+            update_descendants_part_of(category)
+          end
+        end
+
+        def move_filters(old_root, intermediate, new_root)
+          find_filters_for(old_root, intermediate).each do |filter|
+            filter.update!(root_taxonomy_id: new_root.id)
+            @logger.info "      Moved filter: #{filter.internal_name[@locale]} (id: #{filter.id}) -> root #{new_root.id}"
+          end
+        end
+
+        def cleanup_intermediate(intermediate)
+          intermediate.reload
+          if intermediate.children.count.zero?
+            intermediate.destroy!
+            @logger.info "    Deleted intermediate: #{intermediate.name[@locale]}"
+          else
+            @logger.warn "    WARNING: Intermediate still has children, not deleting: #{intermediate.name[@locale]}"
+          end
+        end
+
+        def cleanup_old_root(old_root)
+          old_root.reload
+          if old_root.children.count.zero?
+            remaining_filters = old_root.taxonomy_filters
+            if remaining_filters.any?
+              @logger.warn "  WARNING: Old root still has #{remaining_filters.count} filters. Not deleting."
+            else
+              old_root.destroy!
+              @logger.info "  Deleted old root: #{old_root.name[@locale]}"
+            end
+          else
+            @logger.warn "  WARNING: Old root still has children, not deleting: #{old_root.name[@locale]}"
+          end
+        end
+
+        def update_descendants_part_of(taxonomy)
+          taxonomy.children.each do |child|
+            child.save!
+            update_descendants_part_of(child)
+          end
+        end
+
+        def reset_counters
+          @logger.info "  Resetting taxonomy counters..."
+          @organization.taxonomies.find_each(&:reset_all_counters)
+          Decidim::TaxonomyFilter.where(root_taxonomy: @organization.taxonomies.roots)
+                                 .find_each(&:reset_all_counters)
+        end
+      end
+    end
+  end
+end

--- a/lib/decidim/cfj/taxonomy_plan_flattener.rb
+++ b/lib/decidim/cfj/taxonomy_plan_flattener.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "decidim/cfj/taxonomy_flatten_constants"
+
+module Decidim
+  module Cfj
+    class TaxonomyPlanFlattener
+      include TaxonomyFlattenConstants
+
+      class CollisionError < StandardError; end
+
+      Entry = Struct.new(:original_name, :new_root_name, :children, :filter_data, keyword_init: true)
+
+      attr_reader :result, :summary
+
+      def initialize(data)
+        categories_section = data.dig("imported_taxonomies", "decidim_categories")
+        unless categories_section
+          @result = data
+          @summary = {}
+          return
+        end
+
+        new_categories = flatten_categories(categories_section)
+        @result = data.merge(
+          "imported_taxonomies" => data["imported_taxonomies"].merge("decidim_categories" => new_categories)
+        )
+        @summary = build_summary(new_categories)
+      end
+
+      private
+
+      def flatten_categories(categories_section)
+        entries = categories_section.each_value.flat_map { |root_data| collect_entries(root_data) }
+        detect_collisions!(entries)
+        assemble_categories(entries)
+      end
+
+      def collect_entries(root_data)
+        taxonomies = root_data["taxonomies"] || {}
+        filters = root_data["filters"] || []
+
+        taxonomies.map do |intermediate_name, intermediate_data|
+          new_root_name = compute_new_root_name(intermediate_name)
+          matching_filter = filters.find { |f| f["internal_name"] == intermediate_name }
+
+          Entry.new(
+            original_name: intermediate_name,
+            new_root_name: new_root_name,
+            children: intermediate_data["children"] || {},
+            filter_data: build_filter(new_root_name, matching_filter)
+          )
+        end
+      end
+
+      def assemble_categories(entries)
+        entries.each_with_object({}) do |entry, hash|
+          next if hash.has_key?(entry.new_root_name)
+
+          hash[entry.new_root_name] = {
+            "taxonomies" => entry.children,
+            "filters" => [entry.filter_data]
+          }
+        end
+      end
+
+      def compute_new_root_name(name)
+        name.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
+      end
+
+      def build_filter(new_root_name, matching_filter)
+        new_filter_items = if matching_filter
+                             (matching_filter["items"] || []).filter_map do |item_path|
+                               new_path = item_path[1..]
+                               new_path if new_path&.any?
+                             end
+                           else
+                             []
+                           end
+
+        new_filter = {
+          "name" => new_root_name,
+          "items" => new_filter_items,
+          "components" => matching_filter&.dig("components") || []
+        }
+
+        new_filter["participatory_space_manifests"] = matching_filter["participatory_space_manifests"] if matching_filter&.dig("participatory_space_manifests")
+
+        new_filter
+      end
+
+      def detect_collisions!(entries)
+        grouped = entries.group_by(&:new_root_name)
+        duplicated = grouped.select { |_, group| group.map(&:original_name).uniq.size > 1 }
+        return if duplicated.empty?
+
+        messages = duplicated.map do |new_root_name, group|
+          sources = group.map(&:original_name).uniq
+          "  - #{new_root_name}\n" + sources.map { |s| "      from: #{s}" }.join("\n")
+        end
+
+        raise CollisionError,
+              "Duplicate root names detected after flattening:\n#{messages.join("\n")}\nPlease rename conflicting participatory spaces or adjust the plan manually."
+      end
+
+      def build_summary(new_categories)
+        new_categories.each_with_object({}) do |(name, root_data), summary|
+          taxonomies = root_data["taxonomies"] || {}
+          filters = root_data["filters"] || []
+          filter_items_count = filters.sum { |f| (f["items"] || []).size }
+
+          summary[name] = {
+            taxonomies: taxonomies.map do |tax_name, tax_data|
+              { name: tax_name, children_count: (tax_data["children"] || {}).size }
+            end,
+            filter_items_count: filter_items_count
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/transform_taxonomy_plan.rake
+++ b/lib/tasks/transform_taxonomy_plan.rake
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+# Intermediate level prefix patterns used by the category migration tool.
+# "参加スペース:" for assemblies, "参加型プロセス:" for participatory processes, etc.
+INTERMEDIATE_PREFIXES = /\A(参加スペース|参加型プロセス|Assembly|Participatory process|Conference|Initiative): /
+
+namespace :decidim do
+  namespace :taxonomies do
+    desc "Transform category taxonomy plan to flatten intermediate levels (one root per participatory space)"
+    task :flatten_category_plan, [:file] => :environment do |_task, args|
+      file = args[:file].to_s
+      abort "File not found! [#{file}]" unless File.exist?(file)
+
+      data = JSON.parse(File.read(file))
+      categories_section = data.dig("imported_taxonomies", "decidim_categories")
+
+      unless categories_section
+        puts "No decidim_categories section found in plan. Nothing to transform."
+        next
+      end
+
+      new_categories = {}
+
+      categories_section.each do |_root_name, root_data|
+        taxonomies = root_data["taxonomies"] || {}
+        filters = root_data["filters"] || []
+
+        taxonomies.each do |intermediate_name, intermediate_data|
+          new_root_name = intermediate_name.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
+
+          children = intermediate_data["children"] || {}
+          matching_filter = filters.find { |f| f["internal_name"] == intermediate_name }
+
+          new_filter_items = []
+          if matching_filter
+            (matching_filter["items"] || []).each do |item_path|
+              new_path = item_path[1..]
+              new_filter_items << new_path if new_path.any?
+            end
+          end
+
+          new_filter = {
+            "name" => new_root_name,
+            "items" => new_filter_items,
+            "components" => matching_filter&.dig("components") || []
+          }
+
+          if matching_filter&.dig("participatory_space_manifests")
+            new_filter["participatory_space_manifests"] = matching_filter["participatory_space_manifests"]
+          end
+
+          new_categories[new_root_name] = {
+            "taxonomies" => children,
+            "filters" => [new_filter]
+          }
+        end
+      end
+
+      data["imported_taxonomies"]["decidim_categories"] = new_categories
+
+      output_path = file.sub(/_plan\.json$/, "_plan_flattened.json")
+      File.write(output_path, JSON.pretty_generate(data))
+
+      puts "Transformed plan written to: #{output_path}"
+      puts ""
+      puts "New root taxonomies for categories:"
+      new_categories.each do |name, root_data|
+        taxonomies = root_data["taxonomies"] || {}
+        filters = root_data["filters"] || []
+        puts "  Root: #{name}"
+        puts "    Taxonomies: #{taxonomies.size}"
+        taxonomies.each do |tax_name, tax_data|
+          children_count = (tax_data["children"] || {}).size
+          puts "      - #{tax_name} (children: #{children_count})"
+        end
+        filters.each do |f|
+          puts "    Filter items: #{(f["items"] || []).size}"
+          (f["items"] || []).first(3).each { |item| puts "      #{item.inspect}" }
+          remaining = (f["items"] || []).size - 3
+          puts "      ... and #{remaining} more" if remaining.positive?
+        end
+      end
+
+      puts ""
+      puts "To import: bin/rails decidim:taxonomies:import_plan[#{output_path}]"
+    end
+
+    desc "Check for potential issues before flattening imported category taxonomies (dry run)"
+    task :check_flatten_imported_categories, [:organization_id] => :environment do |_task, args|
+      logger = Logger.new($stdout, formatter: proc { |_severity, _time, _progname, msg| "#{msg}\n" })
+      organizations = target_organizations(args[:organization_id])
+      has_issues = false
+
+      organizations.each do |organization|
+        locale = organization.default_locale
+        logger.info "=== Organization: #{organization.name[locale]} (id: #{organization.id}, host: #{organization.host}) ==="
+
+        category_roots = find_category_roots(organization)
+        if category_roots.empty?
+          logger.info "  No category root taxonomy (\"~ カテゴリ\" / \"~ Categories\") found. Nothing to flatten."
+          next
+        end
+
+        category_roots.each do |old_root|
+          logger.info "  Category root: #{old_root.name[locale]} (id: #{old_root.id})"
+
+          intermediates = old_root.children.to_a
+          if intermediates.empty?
+            logger.info "    No intermediate levels (children). Nothing to flatten."
+            next
+          end
+
+          intermediates.each do |intermediate|
+            categories = intermediate.children
+            new_root_name_value = intermediate.name[locale]&.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
+
+            # Check 1: Does the intermediate name match expected pattern?
+            unless intermediate.name[locale]&.match?(INTERMEDIATE_PREFIXES)
+              has_issues = true
+              logger.info "    [WARNING] Intermediate \"#{intermediate.name[locale]}\" (id: #{intermediate.id}) does not match expected prefix pattern"
+              logger.info "              Expected: \"参加スペース: ...\" or \"参加型プロセス: ...\""
+              logger.info "              This taxonomy will still be processed but the new root name may be unexpected: \"#{new_root_name_value}\""
+            end
+
+            # Check 2: Would the new root name collide with an existing root?
+            existing_root = organization.taxonomies.roots.find_by("name->>? = ?", locale, new_root_name_value)
+            if existing_root
+              has_issues = true
+              logger.info "    [ERROR] New root name \"#{new_root_name_value}\" already exists (id: #{existing_root.id})"
+              logger.info "            This would cause a conflict. Resolve before running flatten."
+            end
+
+            # Check 3: Filters matched?
+            filters = Decidim::TaxonomyFilter.where(root_taxonomy_id: old_root.id).select do |f|
+              f.internal_name[locale] == intermediate.name[locale]
+            end
+            if filters.empty?
+              has_issues = true
+              logger.info "    [WARNING] No TaxonomyFilter found matching intermediate \"#{intermediate.name[locale]}\""
+              logger.info "              Filter items and component assignments may be lost."
+            end
+
+            # Summary
+            logger.info "    Intermediate: #{intermediate.name[locale]} (id: #{intermediate.id})"
+            logger.info "      -> New root: #{new_root_name_value}"
+            logger.info "      Categories to move: #{categories.count}"
+            categories.each do |cat|
+              subcats = cat.children.count
+              logger.info "        - #{cat.name[locale]} (id: #{cat.id}, subcategories: #{subcats})"
+            end
+            logger.info "      Filters to move: #{filters.size}"
+            filters.each do |f|
+              logger.info "        - #{f.internal_name[locale]} (id: #{f.id}, items: #{f.filter_items.count}, components: #{f.components_count})"
+            end
+          end
+        end
+        logger.info ""
+      end
+
+      if has_issues
+        logger.info "=== Issues found. Please review warnings/errors above before running flatten. ==="
+      else
+        logger.info "=== No issues found. Safe to run: bin/rails decidim:taxonomies:flatten_imported_categories ==="
+      end
+    end
+
+    desc "Fix already-imported category taxonomies by flattening intermediate levels. " \
+         "Optionally specify organization_id, e.g. decidim:taxonomies:flatten_imported_categories[42]"
+    task :flatten_imported_categories, [:organization_id] => :environment do |_task, args|
+      logger = Logger.new($stdout, formatter: proc { |_severity, _time, _progname, msg| "#{msg}\n" })
+      organizations = target_organizations(args[:organization_id])
+
+      organizations.each do |organization|
+        locale = organization.default_locale
+        logger.info "Processing organization: #{organization.name[locale]} (id: #{organization.id}, host: #{organization.host})"
+
+        category_roots = find_category_roots(organization)
+        if category_roots.empty?
+          logger.info "  No category root taxonomy found. Skipping."
+          next
+        end
+
+        category_roots.each do |old_root|
+          logger.info "  Found category root: #{old_root.name[locale]} (id: #{old_root.id})"
+
+          intermediates = old_root.children.to_a
+          if intermediates.empty?
+            logger.info "    No intermediate levels found. Skipping."
+            next
+          end
+
+          intermediates.each do |intermediate|
+            logger.info "    Processing intermediate: #{intermediate.name[locale]} (id: #{intermediate.id})"
+
+            new_root_name = intermediate.name.transform_values do |name|
+              name.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
+            end
+
+            # Check for name collision
+            existing = organization.taxonomies.roots.find_by("name->>? = ?", locale, new_root_name[locale])
+            if existing
+              logger.warn "    ERROR: Root taxonomy \"#{new_root_name[locale]}\" already exists (id: #{existing.id}). Skipping this intermediate."
+              next
+            end
+
+            new_root = Decidim::Taxonomy.create!(
+              name: new_root_name,
+              organization: organization,
+              weight: Decidim::Taxonomy.where(parent_id: nil, decidim_organization_id: organization.id).count
+            )
+            logger.info "    Created new root: #{new_root.name[locale]} (id: #{new_root.id})"
+
+            categories = intermediate.children.to_a
+            categories.each do |category|
+              category.update!(parent: new_root)
+              logger.info "      Moved category: #{category.name[locale]} (id: #{category.id})"
+              update_descendants_part_of(category)
+            end
+
+            filters = Decidim::TaxonomyFilter.where(root_taxonomy_id: old_root.id).select do |f|
+              f.internal_name[locale] == intermediate.name[locale]
+            end
+
+            filters.each do |filter|
+              filter.update!(root_taxonomy_id: new_root.id)
+              logger.info "      Moved filter: #{filter.internal_name[locale]} (id: #{filter.id}) -> root #{new_root.id}"
+            end
+
+            # Delete empty intermediate (reload to clear association cache)
+            intermediate.reload
+            if intermediate.children.count.zero?
+              intermediate.destroy!
+              logger.info "    Deleted intermediate: #{intermediate.name[locale]}"
+            else
+              logger.warn "    WARNING: Intermediate still has children, not deleting: #{intermediate.name[locale]}"
+            end
+          end
+
+          # Delete old root if empty
+          old_root.reload
+          if old_root.children.count.zero?
+            remaining_filters = Decidim::TaxonomyFilter.where(root_taxonomy_id: old_root.id)
+            if remaining_filters.any?
+              logger.warn "  WARNING: Old root still has #{remaining_filters.count} filters. Not deleting."
+            else
+              old_root.destroy!
+              logger.info "  Deleted old root: #{old_root.name[locale]}"
+            end
+          else
+            logger.warn "  WARNING: Old root still has children, not deleting: #{old_root.name[locale]}"
+          end
+        end
+
+        # Reset counters
+        logger.info "  Resetting taxonomy counters..."
+        Decidim::Taxonomy.where(decidim_organization_id: organization.id).find_each(&:reset_all_counters)
+        Decidim::TaxonomyFilter.joins(:root_taxonomy)
+                               .where(decidim_taxonomies: { decidim_organization_id: organization.id })
+                               .find_each(&:reset_all_counters)
+
+        logger.info "  Done."
+      end
+    end
+  end
+end
+
+def target_organizations(organization_id)
+  if organization_id.present?
+    org = Decidim::Organization.find_by(id: organization_id)
+    abort "Organization not found: #{organization_id}" unless org
+    [org]
+  else
+    Decidim::Organization.order(:id).to_a
+  end
+end
+
+def find_category_roots(organization)
+  locale = organization.default_locale
+  categories_title = I18n.t("decidim.admin.categories.index.categories_title", locale: locale, default: "Categories")
+  organization.taxonomies.roots.select do |root|
+    name = root.name[locale]
+    name&.start_with?("~ カテゴリ") ||
+      name&.start_with?("~ #{categories_title}")
+  end
+end
+
+def update_descendants_part_of(taxonomy)
+  taxonomy.children.each do |child|
+    child.save! # triggers build_part_of via before_validation
+    update_descendants_part_of(child)
+  end
+end

--- a/lib/tasks/transform_taxonomy_plan.rake
+++ b/lib/tasks/transform_taxonomy_plan.rake
@@ -1,319 +1,7 @@
 # frozen_string_literal: true
 
-# Intermediate level prefix patterns used by the category migration tool.
-# "参加スペース:" for assemblies, "参加型プロセス:" for participatory processes, etc.
-INTERMEDIATE_PREFIXES = /\A(参加スペース|参加型プロセス|Assembly|Participatory process|Conference|Initiative): /
-
-namespace :decidim do
-  namespace :taxonomies do
-    desc "Transform category taxonomy plan to flatten intermediate levels (one root per participatory space)"
-    task :flatten_category_plan, [:file] => :environment do |_task, args|
-      file = args[:file].to_s
-      abort "File not found! [#{file}]" unless File.exist?(file)
-
-      data = JSON.parse(File.read(file))
-      categories_section = data.dig("imported_taxonomies", "decidim_categories")
-
-      unless categories_section
-        puts "No decidim_categories section found in plan. Nothing to transform."
-        next
-      end
-
-      new_categories = {}
-      collisions = Hash.new { |hash, key| hash[key] = [] }
-
-      categories_section.each do |_root_name, root_data|
-        taxonomies = root_data["taxonomies"] || {}
-        filters = root_data["filters"] || []
-
-        taxonomies.each do |intermediate_name, intermediate_data|
-          new_root_name = intermediate_name.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
-          collisions[new_root_name] << intermediate_name
-
-          children = intermediate_data["children"] || {}
-          matching_filter = filters.find { |f| f["internal_name"] == intermediate_name }
-
-          new_filter_items = []
-          if matching_filter
-            (matching_filter["items"] || []).each do |item_path|
-              new_path = item_path[1..]
-              new_filter_items << new_path if new_path.any?
-            end
-          end
-
-          new_filter = {
-            "name" => new_root_name,
-            "items" => new_filter_items,
-            "components" => matching_filter&.dig("components") || []
-          }
-
-          if matching_filter&.dig("participatory_space_manifests")
-            new_filter["participatory_space_manifests"] = matching_filter["participatory_space_manifests"]
-          end
-
-          next if new_categories.key?(new_root_name)
-
-          new_categories[new_root_name] = {
-            "taxonomies" => children,
-            "filters" => [new_filter]
-          }
-        end
-      end
-
-      duplicated_roots = collisions.select { |_name, sources| sources.uniq.size > 1 }
-      if duplicated_roots.any?
-        puts "ERROR: Duplicate root names detected after flattening. Aborting to avoid data loss:"
-        duplicated_roots.each do |new_root_name, sources|
-          puts "  - #{new_root_name}"
-          sources.uniq.each { |source| puts "      from: #{source}" }
-        end
-        puts ""
-        puts "Please rename conflicting participatory spaces or adjust the plan manually."
-        abort "Flattening aborted due to duplicate root names."
-      end
-
-      data["imported_taxonomies"]["decidim_categories"] = new_categories
-
-      output_path = file.sub(/_plan\.json$/, "_plan_flattened.json")
-      File.write(output_path, JSON.pretty_generate(data))
-
-      puts "Transformed plan written to: #{output_path}"
-      puts ""
-      puts "New root taxonomies for categories:"
-      new_categories.each do |name, root_data|
-        taxonomies = root_data["taxonomies"] || {}
-        filters = root_data["filters"] || []
-        puts "  Root: #{name}"
-        puts "    Taxonomies: #{taxonomies.size}"
-        taxonomies.each do |tax_name, tax_data|
-          children_count = (tax_data["children"] || {}).size
-          puts "      - #{tax_name} (children: #{children_count})"
-        end
-        filters.each do |f|
-          puts "    Filter items: #{(f["items"] || []).size}"
-          (f["items"] || []).first(3).each { |item| puts "      #{item.inspect}" }
-          remaining = (f["items"] || []).size - 3
-          puts "      ... and #{remaining} more" if remaining.positive?
-        end
-      end
-
-      puts ""
-      puts "To import: bin/rails decidim:taxonomies:import_plan[#{output_path}]"
-    end
-
-    desc "Check for potential issues before flattening imported category taxonomies (dry run)"
-    task :check_flatten_imported_categories, [:organization_id] => :environment do |_task, args|
-      logger = Logger.new($stdout, formatter: proc { |_severity, _time, _progname, msg| "#{msg}\n" })
-      organizations = target_organizations(args[:organization_id])
-      has_issues = false
-
-      organizations.each do |organization|
-        locale = organization.default_locale
-        logger.info "=== Organization: #{organization.name[locale]} (id: #{organization.id}, host: #{organization.host}) ==="
-
-        category_roots = find_category_roots(organization)
-        if category_roots.empty?
-          logger.info "  No category root taxonomy (\"~ カテゴリ\" / \"~ Categories\") found. Nothing to flatten."
-          next
-        end
-
-        new_root_names_map = Hash.new { |hash, key| hash[key] = [] }
-
-        category_roots.each do |old_root|
-          logger.info "  Category root: #{old_root.name[locale]} (id: #{old_root.id})"
-
-          intermediates = old_root.children.to_a
-          if intermediates.empty?
-            logger.info "    No intermediate levels (children). Nothing to flatten."
-            next
-          end
-
-          intermediates.each do |intermediate|
-            categories = intermediate.children
-            new_root_name_value = intermediate.name[locale]&.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
-            new_root_names_map[new_root_name_value] << intermediate
-
-            # Check 1: Does the intermediate name match expected pattern?
-            unless intermediate.name[locale]&.match?(INTERMEDIATE_PREFIXES)
-              has_issues = true
-              logger.info "    [WARNING] Intermediate \"#{intermediate.name[locale]}\" (id: #{intermediate.id}) does not match expected prefix pattern"
-              logger.info "              Expected: \"参加スペース: ...\" or \"参加型プロセス: ...\""
-              logger.info "              This taxonomy will still be processed but the new root name may be unexpected: \"#{new_root_name_value}\""
-            end
-
-            # Check 2: Would the new root name collide with an existing root?
-            existing_root = organization.taxonomies.roots.find_by("name->>? = ?", locale, new_root_name_value)
-            if existing_root
-              has_issues = true
-              logger.info "    [ERROR] New root name \"#{new_root_name_value}\" already exists (id: #{existing_root.id})"
-              logger.info "            This would cause a conflict. Resolve before running flatten."
-            end
-
-            # Check 3: Filters matched?
-            filters = Decidim::TaxonomyFilter.where(root_taxonomy_id: old_root.id).select do |f|
-              f.internal_name[locale] == intermediate.name[locale]
-            end
-            if filters.empty?
-              has_issues = true
-              logger.info "    [WARNING] No TaxonomyFilter found matching intermediate \"#{intermediate.name[locale]}\""
-              logger.info "              Filter items and component assignments may be lost."
-            end
-
-            # Summary
-            logger.info "    Intermediate: #{intermediate.name[locale]} (id: #{intermediate.id})"
-            logger.info "      -> New root: #{new_root_name_value}"
-            logger.info "      Categories to move: #{categories.count}"
-            categories.each do |cat|
-              subcats = cat.children.count
-              logger.info "        - #{cat.name[locale]} (id: #{cat.id}, subcategories: #{subcats})"
-            end
-            logger.info "      Filters to move: #{filters.size}"
-            filters.each do |f|
-              logger.info "        - #{f.internal_name[locale]} (id: #{f.id}, items: #{f.filter_items.count}, components: #{f.components_count})"
-            end
-          end
-        end
-
-        duplicated_new_roots = new_root_names_map.select { |_name, intermediates| intermediates.size > 1 }
-        duplicated_new_roots.each do |new_name, intermediates|
-          has_issues = true
-          logger.info "    [ERROR] Duplicate new root name detected: \"#{new_name}\""
-          logger.info "            The following intermediates would collide:"
-          intermediates.each do |intermediate|
-            logger.info "              - #{intermediate.name[locale]} (id: #{intermediate.id})"
-          end
-          logger.info "            Flattening would skip data for some intermediates. Resolve before running flatten."
-        end
-
-        logger.info ""
-      end
-
-      if has_issues
-        logger.info "=== Issues found. Please review warnings/errors above before running flatten. ==="
-      else
-        logger.info "=== No issues found. Safe to run: bin/rails decidim:taxonomies:flatten_imported_categories ==="
-      end
-    end
-
-    desc "Fix already-imported category taxonomies by flattening intermediate levels. " \
-         "Optionally specify organization_id, e.g. decidim:taxonomies:flatten_imported_categories[42]"
-    task :flatten_imported_categories, [:organization_id] => :environment do |_task, args|
-      logger = Logger.new($stdout, formatter: proc { |_severity, _time, _progname, msg| "#{msg}\n" })
-      organizations = target_organizations(args[:organization_id])
-
-      organizations.each do |organization|
-        locale = organization.default_locale
-        logger.info "Processing organization: #{organization.name[locale]} (id: #{organization.id}, host: #{organization.host})"
-
-        category_roots = find_category_roots(organization)
-        if category_roots.empty?
-          logger.info "  No category root taxonomy found. Skipping."
-          next
-        end
-
-        new_root_names_map = Hash.new { |hash, key| hash[key] = [] }
-        category_roots.each do |old_root|
-          old_root.children.each do |intermediate|
-            new_root_name_value = intermediate.name[locale]&.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
-            new_root_names_map[new_root_name_value] << intermediate
-          end
-        end
-        duplicated_new_roots = new_root_names_map.select { |_name, intermediates| intermediates.size > 1 }
-        if duplicated_new_roots.any?
-          logger.error "  ERROR: Duplicate new root names detected. Aborting flatten for this organization."
-          duplicated_new_roots.each do |new_name, intermediates|
-            logger.error "    - #{new_name}"
-            intermediates.each do |intermediate|
-              logger.error "        from intermediate: #{intermediate.name[locale]} (id: #{intermediate.id})"
-            end
-          end
-          logger.error "  Resolve naming collisions and rerun."
-          next
-        end
-
-        category_roots.each do |old_root|
-          logger.info "  Found category root: #{old_root.name[locale]} (id: #{old_root.id})"
-
-          intermediates = old_root.children.to_a
-          if intermediates.empty?
-            logger.info "    No intermediate levels found. Skipping."
-            next
-          end
-
-          intermediates.each do |intermediate|
-            logger.info "    Processing intermediate: #{intermediate.name[locale]} (id: #{intermediate.id})"
-
-            new_root_name = intermediate.name.transform_values do |name|
-              name.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
-            end
-
-            # Check for name collision
-            existing = organization.taxonomies.roots.find_by("name->>? = ?", locale, new_root_name[locale])
-            if existing
-              logger.warn "    ERROR: Root taxonomy \"#{new_root_name[locale]}\" already exists (id: #{existing.id}). Skipping this intermediate."
-              next
-            end
-
-            new_root = Decidim::Taxonomy.create!(
-              name: new_root_name,
-              organization: organization,
-              weight: Decidim::Taxonomy.where(parent_id: nil, decidim_organization_id: organization.id).count
-            )
-            logger.info "    Created new root: #{new_root.name[locale]} (id: #{new_root.id})"
-
-            categories = intermediate.children.to_a
-            categories.each do |category|
-              category.update!(parent: new_root)
-              logger.info "      Moved category: #{category.name[locale]} (id: #{category.id})"
-              update_descendants_part_of(category)
-            end
-
-            filters = Decidim::TaxonomyFilter.where(root_taxonomy_id: old_root.id).select do |f|
-              f.internal_name[locale] == intermediate.name[locale]
-            end
-
-            filters.each do |filter|
-              filter.update!(root_taxonomy_id: new_root.id)
-              logger.info "      Moved filter: #{filter.internal_name[locale]} (id: #{filter.id}) -> root #{new_root.id}"
-            end
-
-            # Delete empty intermediate (reload to clear association cache)
-            intermediate.reload
-            if intermediate.children.count.zero?
-              intermediate.destroy!
-              logger.info "    Deleted intermediate: #{intermediate.name[locale]}"
-            else
-              logger.warn "    WARNING: Intermediate still has children, not deleting: #{intermediate.name[locale]}"
-            end
-          end
-
-          # Delete old root if empty
-          old_root.reload
-          if old_root.children.count.zero?
-            remaining_filters = Decidim::TaxonomyFilter.where(root_taxonomy_id: old_root.id)
-            if remaining_filters.any?
-              logger.warn "  WARNING: Old root still has #{remaining_filters.count} filters. Not deleting."
-            else
-              old_root.destroy!
-              logger.info "  Deleted old root: #{old_root.name[locale]}"
-            end
-          else
-            logger.warn "  WARNING: Old root still has children, not deleting: #{old_root.name[locale]}"
-          end
-        end
-
-        # Reset counters
-        logger.info "  Resetting taxonomy counters..."
-        Decidim::Taxonomy.where(decidim_organization_id: organization.id).find_each(&:reset_all_counters)
-        Decidim::TaxonomyFilter.joins(:root_taxonomy)
-                               .where(decidim_taxonomies: { decidim_organization_id: organization.id })
-                               .find_each(&:reset_all_counters)
-
-        logger.info "  Done."
-      end
-    end
-  end
-end
+require "decidim/cfj/taxonomy_plan_flattener"
+require "decidim/cfj/taxonomy_flattener"
 
 def target_organizations(organization_id)
   if organization_id.present?
@@ -325,19 +13,82 @@ def target_organizations(organization_id)
   end
 end
 
-def find_category_roots(organization)
-  locale = organization.default_locale
-  categories_title = I18n.t("decidim.admin.categories.index.categories_title", locale: locale, default: "Categories")
-  organization.taxonomies.roots.select do |root|
-    name = root.name[locale]
-    name&.start_with?("~ カテゴリ") ||
-      name&.start_with?("~ #{categories_title}")
-  end
-end
+namespace :decidim do
+  namespace :taxonomies do
+    desc "カテゴリ分類プランの中間レベルをフラット化する（参加スペースごとに1ルート）"
+    task :flatten_category_plan, [:file] => :environment do |_task, args|
+      file = args[:file].to_s
+      abort "File not found! [#{file}]" unless File.exist?(file)
 
-def update_descendants_part_of(taxonomy)
-  taxonomy.children.each do |child|
-    child.save! # triggers build_part_of via before_validation
-    update_descendants_part_of(child)
+      data = JSON.parse(File.read(file))
+
+      unless data.dig("imported_taxonomies", "decidim_categories")
+        puts "No decidim_categories section found in plan. Nothing to transform."
+        next
+      end
+
+      begin
+        flattener = Decidim::Cfj::TaxonomyPlanFlattener.new(data)
+      rescue Decidim::Cfj::TaxonomyPlanFlattener::CollisionError => e
+        puts "ERROR: #{e.message}"
+        abort "Flattening aborted due to duplicate root names."
+      end
+
+      output_path = file.sub(/_plan\.json$/, "_plan_flattened.json")
+      File.write(output_path, JSON.pretty_generate(flattener.result))
+
+      puts "Transformed plan written to: #{output_path}"
+      puts ""
+      puts "New root taxonomies for categories:"
+      flattener.summary.each do |name, info|
+        puts "  Root: #{name}"
+        puts "    Taxonomies: #{info[:taxonomies].size}"
+        info[:taxonomies].each do |tax|
+          puts "      - #{tax[:name]} (children: #{tax[:children_count]})"
+        end
+        puts "    Filter items: #{info[:filter_items_count]}"
+      end
+
+      puts ""
+      puts "To import: bin/rails decidim:taxonomies:import_plan[#{output_path}]"
+    end
+
+    desc "インポート済みカテゴリ分類のフラット化事前チェック（dry run）"
+    task :check_flatten_imported_categories, [:organization_id] => :environment do |_task, args|
+      logger = Logger.new($stdout, formatter: proc { |_severity, _time, _progname, msg| "#{msg}\n" })
+      organizations = target_organizations(args[:organization_id])
+      has_issues = false
+
+      organizations.each do |organization|
+        locale = organization.default_locale
+        logger.info "=== Organization: #{organization.name[locale]} (id: #{organization.id}, host: #{organization.host}) ==="
+
+        flattener = Decidim::Cfj::TaxonomyFlattener.new(organization, logger: logger)
+        result = flattener.check!
+        has_issues = true unless result
+
+        logger.info ""
+      end
+
+      if has_issues
+        logger.info "=== Issues found. Please review warnings/errors above before running flatten. ==="
+      else
+        logger.info "=== No issues found. Safe to run: bin/rails decidim:taxonomies:flatten_imported_categories ==="
+      end
+    end
+
+    desc "インポート済みカテゴリ分類の中間レベルをフラット化する。organization_id指定可: decidim:taxonomies:flatten_imported_categories[42]"
+    task :flatten_imported_categories, [:organization_id] => :environment do |_task, args|
+      logger = Logger.new($stdout, formatter: proc { |_severity, _time, _progname, msg| "#{msg}\n" })
+      organizations = target_organizations(args[:organization_id])
+
+      organizations.each do |organization|
+        locale = organization.default_locale
+        logger.info "Processing organization: #{organization.name[locale]} (id: #{organization.id}, host: #{organization.host})"
+
+        flattener = Decidim::Cfj::TaxonomyFlattener.new(organization, logger: logger)
+        flattener.flatten!
+      end
+    end
   end
 end

--- a/lib/tasks/transform_taxonomy_plan.rake
+++ b/lib/tasks/transform_taxonomy_plan.rake
@@ -20,6 +20,7 @@ namespace :decidim do
       end
 
       new_categories = {}
+      collisions = Hash.new { |hash, key| hash[key] = [] }
 
       categories_section.each do |_root_name, root_data|
         taxonomies = root_data["taxonomies"] || {}
@@ -27,6 +28,7 @@ namespace :decidim do
 
         taxonomies.each do |intermediate_name, intermediate_data|
           new_root_name = intermediate_name.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
+          collisions[new_root_name] << intermediate_name
 
           children = intermediate_data["children"] || {}
           matching_filter = filters.find { |f| f["internal_name"] == intermediate_name }
@@ -49,11 +51,25 @@ namespace :decidim do
             new_filter["participatory_space_manifests"] = matching_filter["participatory_space_manifests"]
           end
 
+          next if new_categories.key?(new_root_name)
+
           new_categories[new_root_name] = {
             "taxonomies" => children,
             "filters" => [new_filter]
           }
         end
+      end
+
+      duplicated_roots = collisions.select { |_name, sources| sources.uniq.size > 1 }
+      if duplicated_roots.any?
+        puts "ERROR: Duplicate root names detected after flattening. Aborting to avoid data loss:"
+        duplicated_roots.each do |new_root_name, sources|
+          puts "  - #{new_root_name}"
+          sources.uniq.each { |source| puts "      from: #{source}" }
+        end
+        puts ""
+        puts "Please rename conflicting participatory spaces or adjust the plan manually."
+        abort "Flattening aborted due to duplicate root names."
       end
 
       data["imported_taxonomies"]["decidim_categories"] = new_categories
@@ -101,6 +117,8 @@ namespace :decidim do
           next
         end
 
+        new_root_names_map = Hash.new { |hash, key| hash[key] = [] }
+
         category_roots.each do |old_root|
           logger.info "  Category root: #{old_root.name[locale]} (id: #{old_root.id})"
 
@@ -113,6 +131,7 @@ namespace :decidim do
           intermediates.each do |intermediate|
             categories = intermediate.children
             new_root_name_value = intermediate.name[locale]&.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
+            new_root_names_map[new_root_name_value] << intermediate
 
             # Check 1: Does the intermediate name match expected pattern?
             unless intermediate.name[locale]&.match?(INTERMEDIATE_PREFIXES)
@@ -154,6 +173,18 @@ namespace :decidim do
             end
           end
         end
+
+        duplicated_new_roots = new_root_names_map.select { |_name, intermediates| intermediates.size > 1 }
+        duplicated_new_roots.each do |new_name, intermediates|
+          has_issues = true
+          logger.info "    [ERROR] Duplicate new root name detected: \"#{new_name}\""
+          logger.info "            The following intermediates would collide:"
+          intermediates.each do |intermediate|
+            logger.info "              - #{intermediate.name[locale]} (id: #{intermediate.id})"
+          end
+          logger.info "            Flattening would skip data for some intermediates. Resolve before running flatten."
+        end
+
         logger.info ""
       end
 
@@ -177,6 +208,26 @@ namespace :decidim do
         category_roots = find_category_roots(organization)
         if category_roots.empty?
           logger.info "  No category root taxonomy found. Skipping."
+          next
+        end
+
+        new_root_names_map = Hash.new { |hash, key| hash[key] = [] }
+        category_roots.each do |old_root|
+          old_root.children.each do |intermediate|
+            new_root_name_value = intermediate.name[locale]&.sub(INTERMEDIATE_PREFIXES, "カテゴリ: ")
+            new_root_names_map[new_root_name_value] << intermediate
+          end
+        end
+        duplicated_new_roots = new_root_names_map.select { |_name, intermediates| intermediates.size > 1 }
+        if duplicated_new_roots.any?
+          logger.error "  ERROR: Duplicate new root names detected. Aborting flatten for this organization."
+          duplicated_new_roots.each do |new_name, intermediates|
+            logger.error "    - #{new_name}"
+            intermediates.each do |intermediate|
+              logger.error "        from intermediate: #{intermediate.name[locale]} (id: #{intermediate.id})"
+            end
+          end
+          logger.error "  Resolve naming collisions and rerun."
           next
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?

移行用に新しいタスクを追加します。

### `decidim:taxonomies:flatten_category_plan`

インポート前のJSONプランファイルの中間レベルをフラット化します。

```console
bin/rails 'decidim:taxonomies:flatten_category_plan[tmp/taxonomies/localhost_plan.json]'
```

- 入力: `*_plan.json` ファイルパス
- 出力: `*_plan_flattened.json` を同じディレクトリに生成
- 名前衝突がある場合はエラーで中断
- 生成後、`decidim:taxonomies:import_plan` でインポート可能

### `decidim:taxonomies:check_flatten_imported_categories`

インポート済みカテゴリ分類のフラット化事前チェック（dry run）。DBは変更しません。

```console
# 全組織をチェック
bin/rails 'decidim:taxonomies:check_flatten_imported_categories'

# 特定の組織のみチェック
bin/rails 'decidim:taxonomies:check_flatten_imported_categories[1]'
```

- 中間レベルのプレフィックスパターン不一致、名前衝突、フィルター欠落を検出
- 問題がなければ「Safe to run」と表示

### `decidim:taxonomies:flatten_imported_categories`

インポート済みカテゴリ分類の中間レベルを実際にフラット化します。DBを変更します。

```console
# 全組織を処理
bin/rails 'decidim:taxonomies:flatten_imported_categories'

# 特定の組織のみ処理
bin/rails 'decidim:taxonomies:flatten_imported_categories[1]'
```

- 中間レベル（「参加スペース: ...」等）をルートに昇格
- カテゴリ・フィルターを新ルートに移動
- 空になった中間レベル・旧ルートを削除
- 名前衝突がある組織はスキップ
- 実行前に check_flatten_imported_categories での確認を推奨


#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
