### PR TITLE
refactor(debates): align show.html.erb with decidim v0.30

### DIFF
--- a/app/views/decidim/debates/debates/show.html.erb
+++ b/app/views/decidim/debates/debates/show.html.erb
@@ -38,7 +38,7 @@ edit_link(
     <div class="layout-author <%= "has_status" if debate.closed? %>">
       <div class="relative flex items-center justify-center w-full">
         <div class="w-10/12 flex items-center gap-4">
-          <%= cell "decidim/author", debate_presenter.author, skip_profile_link: true %>
+          <%= cell "decidim/author", debate_presenter.author %>
         </div>
         <%= render "decidim/shared/resource_actions", resource: debate do %>
           <%= render "decidim/debates/debates/debate_actions" %>


### PR DESCRIPTION
#### :tophat: What? Why?

Decidim本家の https://github.com/decidim/decidim/pull/15328 ([`4c17aa20`](https://github.com/decidim/decidim/commit/4c17aa20651d03405f8b0d6f0a65103bbde4271f)) "Change user links in Comments and Debates" が decidim-cfj に反映されていなかったので修正します。

ユーザーのリンクがなかった状態からリンクされる状態になります。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

Before:

<img width="363" height="163" alt="スクリーンショット 2026-04-18 2 17 16" src="https://github.com/user-attachments/assets/a8097cfa-a3b9-4af8-b24c-47f52b00be00" />

After:

<img width="352" height="156" alt="スクリーンショット 2026-04-18 2 14 07" src="https://github.com/user-attachments/assets/6c29fdde-2d32-48c7-bf3f-a04c3b230d20" />
