### PR TITLE
fix: enforce permission to unreport

### DIFF
--- a/config/initializers/moderated_users_controller_override.rb
+++ b/config/initializers/moderated_users_controller_override.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Adds the permission check to the bulk_unreport action
+Rails.application.config.to_prepare do
+  Decidim::Admin::ModeratedUsersController # rubocop:disable Lint/Void
+
+  module DecidimAdminModeratedUsersControllerBulkUnreportPatch
+    def bulk_unreport
+      enforce_permission_to :unreport, :moderate_users
+      super
+    end
+  end
+
+  Decidim::Admin::ModeratedUsersController.prepend(DecidimAdminModeratedUsersControllerBulkUnreportPatch)
+end

--- a/spec/requests/decidim/admin/moderated_users_bulk_unreport_spec.rb
+++ b/spec/requests/decidim/admin/moderated_users_bulk_unreport_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Verifies that the bulk_unreport endpoint
+RSpec.describe "Decidim::Admin ModeratedUsersController bulk_unreport" do
+  include Devise::Test::IntegrationHelpers
+
+  let(:organization) { create(:organization) }
+  let(:admin_user) { create(:user, :admin, :confirmed, organization:) }
+  let(:user_manager_user) { create(:user, :user_manager, :confirmed, organization:) }
+  let(:reported_user) { create(:user, :confirmed, organization:) }
+  let!(:user_moderation) { create(:user_moderation, user: reported_user) }
+  let(:params) { { user_ids: [reported_user.id] } }
+
+  before { host! organization.host }
+
+  describe "PATCH bulk_unreport" do
+    context "with a user_manager (dashboard access, no :unreport :moderate_users permission)" do
+      before { sign_in user_manager_user, scope: :user }
+
+      it "does not dismiss the report" do
+        patch decidim_admin.bulk_unreport_moderated_users_path, params: params
+
+        expect(Decidim::UserModeration.exists?(user_moderation.id)).to be true
+      end
+    end
+
+    context "with an organization admin" do
+      before { sign_in admin_user, scope: :user }
+
+      it "dismisses the report" do
+        patch decidim_admin.bulk_unreport_moderated_users_path, params: params
+
+        expect(Decidim::UserModeration.exists?(user_moderation.id)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

#121 と同様に、管理画面のenforce_permission_to を追加します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
