### PR TITLE
ContentBlockのhtml_cellでCSPのframe-srcの設定を活かすよう修正

### DIFF
--- a/app/services/decidim/iframe_disabler.rb
+++ b/app/services/decidim/iframe_disabler.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Decidim
+  class IframeDisabler
+    def initialize(text, _options = {})
+      @text = text
+    end
+
+    def perform
+      @document = Nokogiri::HTML::DocumentFragment.parse(@text)
+      disable_iframes(@document)
+      document.to_html
+    end
+
+    private
+
+    attr_reader :document
+
+    def disable_iframes(node)
+      if node.name == "iframe"
+        # Default title for accessibility
+        node["title"] = I18n.t("decidim.shared.embed.title") if node["title"].blank?
+        # Disable scrollbar for some embed services
+        node["scrolling"] = "no"
+        orig_node = node.to_s
+        node.replace(%(<div class="disabled-iframe"><!-- #{orig_node} --></div>))
+      end
+
+      node.children.each do |child|
+        disable_iframes(child)
+      end
+    end
+  end
+end

--- a/app/services/decidim/iframe_disabler.rb
+++ b/app/services/decidim/iframe_disabler.rb
@@ -18,16 +18,94 @@ module Decidim
 
     def disable_iframes(node)
       if node.name == "iframe"
-        # Default title for accessibility
-        node["title"] = I18n.t("decidim.shared.embed.title") if node["title"].blank?
-        # Disable scrollbar for some embed services
-        node["scrolling"] = "no"
-        orig_node = node.to_s
-        node.replace(%(<div class="disabled-iframe"><!-- #{orig_node} --></div>))
+        src = node["src"]
+        if src && allowed_iframe_domain?(src)
+          # iframe is from an allowed domain, leave it as is
+        else
+          # Default title for accessibility
+          node["title"] = I18n.t("decidim.shared.embed.title") if node["title"].blank?
+          # Disable scrollbar for some embed services
+          node["scrolling"] = "no"
+          orig_node = node.to_s
+          node.replace(%(<div class="disabled-iframe"><!-- #{orig_node} --></div>))
+        end
       end
 
       node.children.each do |child|
         disable_iframes(child)
+      end
+    end
+
+    def allowed_iframe_domain?(src)
+      allowed_domains = Decidim.config.content_security_policies_extra.dig("frame-src") || [] # rubocop:disable Style/SingleArgumentDig
+      return false if allowed_domains.include?("'none'")
+      return true if allowed_domains.include?("*")
+
+      begin
+        src_uri = URI.parse(src)
+        src_scheme = src_uri.scheme
+        src_hostname = src_uri.hostname || ""
+
+        allowed_domains.any? do |domain|
+          matches_csp_rule?(src_scheme, src_hostname, domain)
+        end
+      rescue URI::InvalidURIError
+        false
+      end
+    end
+
+    def matches_csp_rule?(src_scheme, src_hostname, domain)
+      case domain
+      when "'self'"
+        false # Self can be handled separately if needed
+      when "'none'" # rubocop:disable Lint/DuplicateBranch
+        false
+      when /^(https?|data|blob):$/
+        # Scheme matching
+        domain_scheme = domain[0..-2] # Remove trailing colon
+        src_scheme == domain_scheme
+      when "*"
+        true
+      else
+        # Hostname matching (with optional wildcards and ports)
+        match_hostname_rule?(src_hostname, domain)
+      end
+    end
+
+    def match_hostname_rule?(src_hostname, domain)
+      # Extract base hostname from CSP domain (which may include protocol, port, path)
+      normalized_domain = extract_hostname(domain)
+      return false if normalized_domain.blank?
+
+      # Handle wildcard subdomains (*.example.com)
+      if normalized_domain.start_with?("*.")
+        base_domain = normalized_domain[2..] # Remove "*."
+        src_hostname.end_with?(".#{base_domain}") || src_hostname == base_domain
+      else
+        src_hostname == normalized_domain || src_hostname.end_with?(".#{normalized_domain}")
+      end
+    end
+
+    def extract_hostname(domain)
+      # Remove 'self', 'none' keywords
+      return nil if domain.start_with?("'")
+
+      # Add https:// scheme if not present (but not for bare scheme values like "https:")
+      domain_to_parse = if domain.match?(%r{^https?://})
+                          domain
+                        elsif !domain.include?(":") # rubocop:disable Rails/NegateInclude
+                          "https://#{domain}"
+                        else
+                          # Bare scheme like "https:" - handle separately
+                          return nil
+                        end
+
+      begin
+        uri = URI.parse(domain_to_parse)
+        uri.hostname
+      rescue URI::InvalidURIError
+        # Fallback: try to extract hostname manually
+        domain.gsub(%r{^https?://}, "").split("/").first.split(":").first
       end
     end
   end

--- a/spec/services/decidim/iframe_disabler_spec.rb
+++ b/spec/services/decidim/iframe_disabler_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Decidim::IframeDisabler do
+  subject { described_class.new(html).perform }
+
+  context "when frame-src allows all domains" do
+    before do
+      allow(Decidim.config.content_security_policies_extra).to receive(:dig)
+        .with("frame-src")
+        .and_return(["*"])
+    end
+
+    let(:html) { '<iframe src="https://example.com/embed"></iframe>' }
+
+    it "keeps the iframe" do
+      expect(subject).to include('<iframe src="https://example.com/embed">')
+    end
+  end
+
+  context "when frame-src has allowed domains" do
+    before do
+      allow(Decidim.config.content_security_policies_extra).to receive(:dig)
+        .with("frame-src")
+        .and_return(%w(https://www.youtube.com www.youtube-nocookie.com))
+    end
+
+    context "with allowed domain" do
+      let(:html) { '<iframe src="https://www.youtube.com/embed/abc123"></iframe>' }
+
+      it "keeps the iframe" do
+        expect(subject).to include('<iframe src="https://www.youtube.com/embed/abc123">')
+      end
+    end
+
+    context "with allowed subdomain" do
+      let(:html) { '<iframe src="https://subdomain.www.youtube-nocookie.com/embed"></iframe>' }
+
+      it "keeps the iframe" do
+        expect(subject).to include('<iframe src="https://subdomain.www.youtube-nocookie.com/embed">')
+      end
+    end
+
+    context "with not allowed domain" do
+      let(:html) { '<iframe src="https://example.com/embed"></iframe>' }
+
+      it "disables the iframe" do
+        expect(subject).to include('class="disabled-iframe"')
+        expect(subject).to include("disabled-iframe")
+        expect(subject).not_to include('<iframe src="https://example.com/embed"></iframe>')
+      end
+    end
+  end
+
+  context "when frame-src is empty or not configured" do
+    before do
+      allow(Decidim.config.content_security_policies_extra).to receive(:dig)
+        .with("frame-src")
+        .and_return(nil)
+    end
+
+    let(:html) { '<iframe src="https://example.com/embed"></iframe>' }
+
+    it "disables all iframes" do
+      expect(subject).to include('class="disabled-iframe"')
+      expect(subject).not_to include('<iframe src="https://example.com/embed"></iframe>')
+    end
+  end
+
+  context "with invalid iframe src" do
+    before do
+      allow(Decidim.config.content_security_policies_extra).to receive(:dig)
+        .with("frame-src")
+        .and_return(%w(https://www.youtube.com))
+    end
+
+    let(:html) { '<iframe src=":::invalid:::"></iframe>' }
+
+    it "disables the iframe" do
+      expect(subject).to include('class="disabled-iframe"')
+    end
+  end
+
+  context "with multiple iframes" do
+    before do
+      allow(Decidim.config.content_security_policies_extra).to receive(:dig)
+        .with("frame-src")
+        .and_return(%w(https://www.youtube.com))
+    end
+
+    let(:html) do
+      '<div><iframe src="https://www.youtube.com/embed/abc"></iframe><iframe src="https://example.com/embed"></iframe></div>'
+    end
+
+    it "keeps allowed iframe and disables others" do
+      expect(subject).to include('<iframe src="https://www.youtube.com/embed/abc">')
+      expect(subject).to include('class="disabled-iframe"')
+      expect(subject).not_to include('<iframe src="https://example.com/embed"></iframe>')
+    end
+  end
+
+  context "with CSP keyword values" do
+    context "when frame-src contains 'none'" do
+      before do
+        allow(Decidim.config.content_security_policies_extra).to receive(:dig)
+          .with("frame-src")
+          .and_return(["'none'"])
+      end
+
+      let(:html) { '<iframe src="https://www.youtube.com/embed/abc"></iframe>' }
+
+      it "disables all iframes" do
+        expect(subject).to include('class="disabled-iframe"')
+      end
+    end
+  end
+
+  context "with CSP scheme values" do
+    context "when frame-src allows https: scheme" do
+      before do
+        allow(Decidim.config.content_security_policies_extra).to receive(:dig)
+          .with("frame-src")
+          .and_return(["https:"])
+      end
+
+      context "with https iframe" do
+        let(:html) { '<iframe src="https://example.com/embed"></iframe>' }
+
+        it "keeps the iframe" do
+          expect(subject).to include('<iframe src="https://example.com/embed">')
+        end
+      end
+
+      context "with http iframe" do
+        let(:html) { '<iframe src="http://example.com/embed"></iframe>' }
+
+        it "disables the iframe" do
+          expect(subject).to include('class="disabled-iframe"')
+        end
+      end
+    end
+  end
+
+  context "with wildcard subdomains" do
+    before do
+      allow(Decidim.config.content_security_policies_extra).to receive(:dig)
+        .with("frame-src")
+        .and_return(["*.example.com"])
+    end
+
+    context "with matching subdomain" do
+      let(:html) { '<iframe src="https://api.example.com/embed"></iframe>' }
+
+      it "keeps the iframe" do
+        expect(subject).to include('<iframe src="https://api.example.com/embed">')
+      end
+    end
+
+    context "with base domain" do
+      let(:html) { '<iframe src="https://example.com/embed"></iframe>' }
+
+      it "keeps the iframe" do
+        expect(subject).to include('<iframe src="https://example.com/embed">')
+      end
+    end
+
+    context "with non-matching domain" do
+      let(:html) { '<iframe src="https://other.com/embed"></iframe>' }
+
+      it "disables the iframe" do
+        expect(subject).to include('class="disabled-iframe"')
+      end
+    end
+  end
+
+  context "with CSP domain with port" do
+    before do
+      allow(Decidim.config.content_security_policies_extra).to receive(:dig)
+        .with("frame-src")
+        .and_return(["https://example.com:443"])
+    end
+
+    context "and matching domain (port ignored for hostname)" do
+      let(:html) { '<iframe src="https://example.com/embed"></iframe>' }
+
+      it "keeps the iframe" do
+        expect(subject).to include('<iframe src="https://example.com/embed">')
+      end
+    end
+  end
+
+  context "with CSP domain with path" do
+    before do
+      allow(Decidim.config.content_security_policies_extra).to receive(:dig)
+        .with("frame-src")
+        .and_return(["https://example.com/path/"])
+    end
+
+    context "and matching domain (path ignored for hostname)" do
+      let(:html) { '<iframe src="https://example.com/different/path"></iframe>' }
+
+      it "keeps the iframe" do
+        expect(subject).to include('<iframe src="https://example.com/different/path">')
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

v0.30のhtml_cellはiframe要素の埋め込みを許可しないようにしています。
が、CSPのframe-srcで許可されているiframe要素なら埋め込めてもいいのでは、ということで設定を有効にするようDecidim::IframeDisablerを変更します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
