### PR TITLE
fix: override comments_count registration in initializers

### DIFF
--- a/config/initializers/comments_count.rb
+++ b/config/initializers/comments_count.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.config.to_prepare do
-  # Add :comment_count to accountability_component's stat
+  # Add :comments_count to accountability_component's stat
   accountability_component = Decidim.find_component_manifest(:accountability)
   if accountability_component.stats.only([:comments_count]).stats.blank?
     accountability_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
@@ -10,16 +10,15 @@ Rails.application.config.to_prepare do
     end
   end
 
-  # Add :comment_count to blogs_component's stat
+  # Override :comments_count on blogs_component.
   blogs_component = Decidim.find_component_manifest(:blogs)
-  if blogs_component.stats.only([:comments_count]).stats.blank?
-    blogs_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
-      posts = Decidim::Blogs::FilteredPosts.for(components, start_at, end_at)
-      posts.sum(:comments_count)
-    end
+  blogs_component.stats.stats.reject! { |s| s[:name] == :comments_count }
+  blogs_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+    posts = Decidim::Blogs::FilteredPosts.for(components, start_at, end_at)
+    posts.sum(:comments_count)
   end
 
-  # Add :comment_count to debates_component's stat
+  # Add :comments_count to debates_component's stat
   debates_component = Decidim.find_component_manifest(:debates)
   if debates_component.stats.only([:comments_count]).stats.blank?
     debates_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
@@ -28,7 +27,7 @@ Rails.application.config.to_prepare do
     end
   end
 
-  # Add :comment_count to sortitions_component's stat
+  # Add :comments_count to sortitions_component's stat
   sortitions_component = Decidim.find_component_manifest(:sortitions)
   if sortitions_component.stats.only([:comments_count]).stats.blank?
     sortitions_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|

--- a/config/initializers/comments_count.rb
+++ b/config/initializers/comments_count.rb
@@ -3,11 +3,9 @@
 Rails.application.config.to_prepare do
   # Add :comments_count to accountability_component's stat
   accountability_component = Decidim.find_component_manifest(:accountability)
-  if accountability_component.stats.only([:comments_count]).stats.blank?
-    accountability_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
-      results = Decidim::Accountability::FilteredResults.for(components, start_at, end_at)
-      results.sum(:comments_count)
-    end
+  accountability_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+    results = Decidim::Accountability::FilteredResults.for(components, start_at, end_at)
+    results.sum(:comments_count)
   end
 
   # Override :comments_count on blogs_component.
@@ -20,19 +18,15 @@ Rails.application.config.to_prepare do
 
   # Add :comments_count to debates_component's stat
   debates_component = Decidim.find_component_manifest(:debates)
-  if debates_component.stats.only([:comments_count]).stats.blank?
-    debates_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
-      debates = Decidim::Debates::FilteredDebates.for(components, start_at, end_at)
-      debates.sum(:comments_count)
-    end
+  debates_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+    debates = Decidim::Debates::FilteredDebates.for(components, start_at, end_at)
+    debates.sum(:comments_count)
   end
 
   # Add :comments_count to sortitions_component's stat
   sortitions_component = Decidim.find_component_manifest(:sortitions)
-  if sortitions_component.stats.only([:comments_count]).stats.blank?
-    sortitions_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
-      sortitions = Decidim::Sortitions::FilteredSortitions.for(components, start_at, end_at)
-      sortitions.sum(:comments_count)
-    end
+  sortitions_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+    sortitions = Decidim::Sortitions::FilteredSortitions.for(components, start_at, end_at)
+    sortitions.sum(:comments_count)
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

comments_count の集計を変更します。

- Blogコンポーネントについて、v0.30では本家でも https://github.com/decidim/decidim/pull/15707 でcomments_countが登録されたけれど計算が間違ってる（?!）ので上書きするよう修正
- それ以外のコンポーネントについても、ifガードはない方が良さそう（本家で登録された場合は衝突してエラーになった方が早期発見できてうれしいのでは？という判断）、ということでifガードは削除

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/15707

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

