### PR TITLE
fix: remove DM features in v0.30

### DIFF
--- a/config/initializers/disable_messaging.rb
+++ b/config/initializers/disable_messaging.rb
@@ -30,12 +30,24 @@ module DisableMessaging
       message.perform_deliveries = false
     end
   end
+
+  # Hides the "Conversations" tab (DM feature) from user group profile pages.
+  # NOTE: This can be removed if/when Decidim drops UserGroup
+  module HideGroupConversationsTab
+    def group_tabs
+      items = [:members].tap do |keys|
+        keys.append(:badges, :followers)
+      end
+      items.map { |key| tab_item(key) }
+    end
+  end
 end
 
 Rails.application.config.to_prepare do
   Decidim::User.prepend(DisableMessaging::RejectAllConversations)
   Decidim::UserPresenter.prepend(DisableMessaging::ForbidContact)
   Decidim::Messaging::ConversationMailer.prepend(DisableMessaging::SuppressMailerDelivery)
+  Decidim::ProfileCell.prepend(DisableMessaging::HideGroupConversationsTab)
 
   # decidim-admin moderation reports list the reportable's authors with an
   # unconditional "start conversation" link wrapping the user name. Since DM

--- a/config/initializers/fix_notification_can_participate.rb
+++ b/config/initializers/fix_notification_can_participate.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Workaround for Decidim bug where Notification#can_participate?
+# delegates unconditionally to resource, but UserGroup (and potentially other
+# resource types) do not implement can_participate?.
+module FixNotificationCanParticipate
+  def can_participate?(user = nil)
+    return unless resource.respond_to?(:can_participate?)
+
+    resource.can_participate?(user)
+  end
+end
+
+Rails.application.config.to_prepare do
+  Decidim::Notification.prepend(FixNotificationCanParticipate)
+end

--- a/config/initializers/fix_notification_can_participate.rb
+++ b/config/initializers/fix_notification_can_participate.rb
@@ -5,7 +5,7 @@
 # resource types) do not implement can_participate?.
 module FixNotificationCanParticipate
   def can_participate?(user = nil)
-    return unless resource.respond_to?(:can_participate?)
+    return false unless resource.respond_to?(:can_participate?)
 
     resource.can_participate?(user)
   end


### PR DESCRIPTION
#### :tophat: What? Why?

v0.30用のDMの修正追加です。

- UserGroupの時にConversationsタブが出ることがあるようだったので、それを抑止します
- また`/notifications`でエラーが出ることがあるようだったので、その修正です

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
