### PR TITLE
fix: disable DM in Open Data

### DIFF
--- a/config/initializers/disable_messaging.rb
+++ b/config/initializers/disable_messaging.rb
@@ -9,6 +9,8 @@
 #   hide their contact buttons.
 # - Suppresses all ConversationMailer deliveries as a defense in depth in case a
 #   conversation record is somehow created (e.g. via background jobs).
+# - Forces the Open Data users export column direct_messages_enabled to false
+#   (it bypasses #accepts_conversation? and reads the raw user attribute).
 # Routes are also redirected at config/routes.rb.
 
 module DisableMessaging
@@ -31,6 +33,16 @@ module DisableMessaging
     end
   end
 
+  # The Open Data users export derives this column directly from the
+  # +direct_message_types+ user attribute, bypassing #accepts_conversation?.
+  # Force it to false so the public dataset never advertises DM availability.
+  # The key is kept (not removed) to preserve the Open Data schema/columns.
+  module ForceOpenDataDirectMessagesDisabled
+    def serialize
+      super.merge(direct_messages_enabled: false)
+    end
+  end
+
   # Hides the "Conversations" tab (DM feature) from user group profile pages.
   # NOTE: This can be removed if/when Decidim drops UserGroup
   module HideGroupConversationsTab
@@ -48,6 +60,7 @@ Rails.application.config.to_prepare do
   Decidim::UserPresenter.prepend(DisableMessaging::ForbidContact)
   Decidim::Messaging::ConversationMailer.prepend(DisableMessaging::SuppressMailerDelivery)
   Decidim::ProfileCell.prepend(DisableMessaging::HideGroupConversationsTab)
+  Decidim::Exporters::OpenDataUserSerializer.prepend(DisableMessaging::ForceOpenDataDirectMessagesDisabled)
 
   # decidim-admin moderation reports list the reportable's authors with an
   # unconditional "start conversation" link wrapping the user name. Since DM

--- a/spec/requests/disable_dm_feature_spec.rb
+++ b/spec/requests/disable_dm_feature_spec.rb
@@ -111,6 +111,19 @@ RSpec.describe "Disable DM feature" do
     end
   end
 
+  describe "Decidim::Exporters::OpenDataUserSerializer" do
+    subject(:serialized) { Decidim::Exporters::OpenDataUserSerializer.new(user).serialize }
+
+    it "forces direct_messages_enabled to false even when the user allows DMs" do
+      user.update!(direct_message_types: "all")
+      expect(serialized[:direct_messages_enabled]).to be(false)
+    end
+
+    it "keeps the direct_messages_enabled key so the Open Data schema is preserved" do
+      expect(serialized).to have_key(:direct_messages_enabled)
+    end
+  end
+
   describe "Decidim::Messaging::ConversationMailer" do
     let(:conversation) do
       create(:conversation, originator: user, interlocutors: [other_user], user:, body: "hi")


### PR DESCRIPTION
#### :tophat: What? Why?

DM関連で追加です。Open Dataのエクスポートでもdisableにするものです。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
