### PR TITLE
fix: show correctly SVG in every login button

### DIFF
--- a/app/packs/stylesheets/decidim/cfj/login.scss
+++ b/app/packs/stylesheets/decidim/cfj/login.scss
@@ -1,13 +1,7 @@
 // Override default login button style
 // cf. https://github.com/decidim/decidim/pull/14276
-.button--developer {
-    @apply flex;
-    svg {
-          @apply fill-current;
-    }
-}
-
-.button--line {
+// Applies to every omniauth provider button (button--<provider>)
+.login__omniauth [class*="button--"] {
     @apply flex;
     svg {
           @apply fill-current;


### PR DESCRIPTION
#### :tophat: What? Why?

個別の指定をやめて、`.login__omniauth`の中に`button--<provider>`があれば全部対応されるように修正します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
