### PR TITLE
fix: update content_security_policies_extra in initializers

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -400,7 +400,6 @@ Decidim.configure do |config|
     "script-src" => ["*"],
     "style-src" => ["*"],
     "font-src" => ["*"],
-    "frame-src" => ["*"],
     "connect-src" => ["*"]
   }
 end


### PR DESCRIPTION
#### :tophat: What? Why?

v0.29とv0.30とでCSPの設定が変わってしまい（decidimのバグのせい？）、現状のままだとframe-srcがゆるくなってしまうようなので、v0.29と同様になるように修正します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
